### PR TITLE
chore: bump projects devDependencies

### DIFF
--- a/projects/parcel-ts/package.json
+++ b/projects/parcel-ts/package.json
@@ -10,7 +10,7 @@
     "@maxgraph/core": "*"
   },
   "devDependencies": {
-    "parcel": "~2.7.0",
-    "typescript": "~4.8.4"
+    "parcel": "~2.8.2",
+    "typescript": "~4.9.4"
   }
 }

--- a/projects/rollup-ts/package.json
+++ b/projects/rollup-ts/package.json
@@ -12,13 +12,13 @@
     "@maxgraph/core": "*"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "~14.1.0",
+    "@rollup/plugin-node-resolve": "~15.0.1",
+    "@rollup/plugin-terser": "~0.3.0",
+    "@rollup/plugin-typescript": "~11.0.0",
     "npm-run-all": "~4.1.5",
-    "rollup": "~2.79.1",
-    "rollup-plugin-terser": "~7.0.2",
-    "rollup-plugin-typescript": "~1.0.1",
-    "serve": "~14.0.1",
-    "tslib": "~2.4.0",
-    "typescript": "~4.8.4"
+    "rollup": "~3.10.0",
+    "serve": "~14.1.2",
+    "tslib": "~2.4.1",
+    "typescript": "~4.9.4"
   }
 }

--- a/projects/rollup-ts/rollup.config.mjs
+++ b/projects/rollup-ts/rollup.config.mjs
@@ -1,6 +1,6 @@
 import resolve from '@rollup/plugin-node-resolve';
-import typescript from 'rollup-plugin-typescript';
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
+import typescript from '@rollup/plugin-typescript';
 
 // `npm run build` -> `production` is true
 // `npm run dev` -> `production` is false

--- a/projects/vitejs-ts/package.json
+++ b/projects/vitejs-ts/package.json
@@ -11,7 +11,7 @@
     "@maxgraph/core": "*"
   },
   "devDependencies": {
-    "typescript": "~4.8.4",
-    "vite": "~3.1.6"
+    "typescript": "~4.9.4",
+    "vite": "~4.0.4"
   }
 }


### PR DESCRIPTION
parcel
  - parcel from 2.7.0 to 2.8.2
  - typescript from 4.8.4 to 4.9.4

vite
  - typescript from 4.8.4 to 4.9.4
  - vite from 3.1.6 to 4.0.4

rollup
  - rollup 2.79.1 to 3.10.0 + configuration update
  - switch from rollup-plugin-terser to @rollup/plugin-terser
  - switch from rollup-plugin-typescript to @rollup/plugin-typescript