### PR TITLE
chore: use maxgraph@core 0.1.0

### DIFF
--- a/.github/workflows/check-typescript-projects.yml
+++ b/.github/workflows/check-typescript-projects.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build_maxgraph_package:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
      - uses: actions/checkout@v3
        with:
@@ -46,38 +46,35 @@ jobs:
            packages/core/maxgraph-core-*.tgz
 
   build_example:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build_maxgraph_package]
     strategy:
       # don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
         project: [parcel-ts, rollup-ts, vitejs-ts]
-    env:
-      project_dir: ${{github.workspace}}/projects/${{matrix.project}}
-      maxgraph_package_dir: ${{github.workspace}}/..
+        npm-package: ['release', 'development']
+    defaults:
+      run:
+        working-directory: ${{github.workspace}}/projects/${{matrix.project}}
     steps:
-      - name: Download maxgraph npm package
+      - name: Download the maxgraph npm package
+        if: ${{ matrix.npm-package == 'development' }}
+        id: 'download'
         uses: actions/download-artifact@v3
         with:
           name: maxgraph-npm-package
-          path: ${{env.maxgraph_package_dir}}
-      - name: Get path to the maxgraph npm package archive
-        working-directory: ${{env.maxgraph_package_dir}}
-        run: |
-          echo "pwd:" && pwd
-          echo "ls:" && ls -lh
-          echo "package file:" && ls maxgraph-core*
-          echo "path:" && echo "`pwd`/`ls maxgraph-core*`"
-          echo "maxgraph_package_path=`pwd`/`ls maxgraph-core*`" >> $GITHUB_ENV
+          path: ${{github.workspace}}/../maxgraph-npm-package
       - uses: actions/checkout@v3
       - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-      - name: Install dependencies and link the local maxgraph npm package
-        working-directory: ${{env.project_dir}}
-        run: npm install ${{env.maxgraph_package_path}}
+      - name: Install dependencies
+        run: npm install
+      - name: Install maxgraph development npm package
+        if: ${{ matrix.npm-package == 'development' }}
+        # use wildcard as the file contains the version, and we don't know it
+        run: npm install ${{steps.download.outputs.download-path}}/maxgraph-core*.tgz
       - name: Build project
-        working-directory: ${{env.project_dir}}
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Demonstrate how to integrate [maxGraph](https://github.com/maxGraph/maxGraph/) in projects.
 
-**Important**: currently, there is no package published on npmjs, so use the [maxGraph development version](#maxgraph-dev-version) 
-
 ## Getting started
 
 ### Setup
@@ -18,6 +16,13 @@ nvm use
 If the Node version is not installed, `nvm` will state how to install the required version.
 
 
+### Available projects
+
+- [TypeScript with Parcel](./projects/parcel-ts/README.md)
+- [TypeScript with Rollup](./projects/rollup-ts/README.md)
+- [TypeScript with ViteJs](./projects/vitejs-ts/README.md)
+
+
 ### <a id="maxgraph-dev-version"></a> Use the maxGraph development version
 
 Build [maxGraph](https://github.com/maxGraph/maxGraph/) locally:
@@ -30,10 +35,3 @@ In this folder where you clone the `maxgraph-integration-examples` project, go t
   Repack of maxgraph is automatically available in the examples
   - alternative: `npm install <path_to_locally_installed_maxgraph>/packages/core/maxgraph-core-0.1.0.tgz`. This changes
   the package.json file. You must run this command again each time you rebuild the maxgraph npm package.
-
-
-### Available projects
-
-- [TypeScript with Parcel](./projects/parcel-ts/README.md)
-- [TypeScript with Rollup](./projects/rollup-ts/README.md)
-- [TypeScript with ViteJs](./projects/vitejs-ts/README.md)

--- a/projects/parcel-ts/README.md
+++ b/projects/parcel-ts/README.md
@@ -2,12 +2,14 @@
 
 Parcel v2 is used in this TypeScript project: https://parceljs.org
 
-<!-- not working for now, no package available on npmjs
+## Setup
+
 From the project root, run `npm install`.
--->
 
-See the README about maxGraph integration.
+If you want to use the maxGraph development version (built locally), see the README about maxGraph integration.
 
-Then, run `npm run dev` and go to http://localhost:1234/
+## Running the project
+
+Run `npm run dev` and go to http://localhost:1234/
 
 If you want to bundle the application, run `npm run build`.

--- a/projects/parcel-ts/package.json
+++ b/projects/parcel-ts/package.json
@@ -7,7 +7,7 @@
     "build": "tsc && parcel build index.html"
   },
   "dependencies": {
-    "@maxgraph/core": "*"
+    "@maxgraph/core": "0.1.0"
   },
   "devDependencies": {
     "parcel": "~2.8.2",

--- a/projects/rollup-ts/README.md
+++ b/projects/rollup-ts/README.md
@@ -9,13 +9,9 @@ Adapted from https://github.com/typed-mxgraph/typed-mxgraph-example-bundled-with
 
 ### Setup
 
-See the README about maxGraph integration.
+From the project root, run `npm install`.
 
-<!-- does not work for now
-```shell
-npm install
-```
--->
+If you want to use the maxGraph development version (built locally), see the README about maxGraph integration.
 
 ### Running the project
 

--- a/projects/rollup-ts/package.json
+++ b/projects/rollup-ts/package.json
@@ -9,7 +9,7 @@
     "start": "serve public"
   },
   "dependencies": {
-    "@maxgraph/core": "*"
+    "@maxgraph/core": "0.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "~15.0.1",

--- a/projects/vitejs-ts/README.md
+++ b/projects/vitejs-ts/README.md
@@ -2,13 +2,15 @@
 
 Initialized from https://github.com/vitejs/vite/tree/v2.9.8/packages/create-vite/template-vanilla-ts
 
-<!-- not working for now, no package available on npmjs
+## Setup
+
 From the project root, run `npm install`.
--->
 
-See the README about maxGraph integration.
+If you want to use the maxGraph development version (built locally), see the README about maxGraph integration.
 
-Then, run `npm run dev` and go to http://localhost:5173/
+## Running the project
+
+Run `npm run dev` and go to http://localhost:5173/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the
 bundle application.

--- a/projects/vitejs-ts/package.json
+++ b/projects/vitejs-ts/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@maxgraph/core": "*"
+    "@maxgraph/core": "0.1.0"
   },
   "devDependencies": {
     "typescript": "~4.9.4",


### PR DESCRIPTION
The workflow now build the projects with both the maxGraph version declared in package.json and a locally built development version.
Also bump the ubuntu runner from 20.04 to 22.04.

fixes #22 