### PR TITLE
chore(dev-deps): bump dev dependencies

### DIFF
--- a/projects/lit-ts/package-lock.json
+++ b/projects/lit-ts/package-lock.json
@@ -12,8 +12,8 @@
         "lit": "~2.7.6"
       },
       "devDependencies": {
-        "typescript": "~5.1.6",
-        "vite": "~4.4.2"
+        "typescript": "~5.2.2",
+        "vite": "~4.4.11"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -426,9 +426,9 @@
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -467,6 +467,8 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true,
       "funding": [
         {
@@ -474,7 +476,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -484,11 +485,14 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.4.24",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {
@@ -504,7 +508,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -515,9 +518,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.26.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.2.tgz",
-      "integrity": "sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==",
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -532,16 +535,17 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -552,14 +556,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.2.tgz",
-      "integrity": "sha512-zUcsJN+UvdSyHhYa277UHhiJ3iq4hUBwHavOpsNUGsTgjBeoBlK8eDt+iT09pBq0h9/knhG/SPrZiM7cGmg7NA==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
+      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
-        "postcss": "^8.4.24",
-        "rollup": "^3.25.2"
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/projects/lit-ts/package.json
+++ b/projects/lit-ts/package.json
@@ -12,7 +12,7 @@
     "lit": "~2.7.6"
   },
   "devDependencies": {
-    "vite": "~4.4.2",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2",
+    "vite": "~4.4.11"
   }
 }

--- a/projects/parcel-ts/package-lock.json
+++ b/projects/parcel-ts/package-lock.json
@@ -11,39 +11,102 @@
         "@maxgraph/core": "0.3.0"
       },
       "devDependencies": {
-        "parcel": "~2.9.3",
-        "typescript": "~5.1.6"
+        "parcel": "~2.10.0",
+        "typescript": "~5.2.2"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.5"
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -113,24 +176,24 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "0.15.12",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
-      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.1.0.tgz",
+      "integrity": "sha512-XPIN3cYDXsoJI/oDWoR2tD++juVrhgIago9xyKhZ7IhGlzdDM9QgC8D8saKNCz5pindGcznFr2HBSsEQSWnSjw==",
       "dev": true
     },
     "node_modules/@lezer/lr": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
-      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.13.tgz",
+      "integrity": "sha512-RLAbau/4uSzKgIKj96mI5WUtG1qtiR0Frn0Ei9zhPj8YOkHM+1Bb8SgdVvmR/aWJCFIzjo2KFnDiRZ75Xf5NdQ==",
       "dev": true,
       "dependencies": {
-        "@lezer/common": "^0.15.0"
+        "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.7.11.tgz",
-      "integrity": "sha512-r6+vYq2vKzE+vgj/rNVRMwAevq0+ZR9IeMFIqcSga+wMtMdXQ27KqQ7uS99/yXASg29bos7yHP3yk4x6Iio0lw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.8.5.tgz",
+      "integrity": "sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==",
       "cpu": [
         "arm64"
       ],
@@ -141,9 +204,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-darwin-x64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.7.11.tgz",
-      "integrity": "sha512-jhj1aB4K8ycRL1HOQT5OtzlqOq70jxUQEWRN9Gqh3TIDN30dxXtiHi6EWF516tzw6v2+3QqhDMJh8O6DtTGG8Q==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.8.5.tgz",
+      "integrity": "sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug==",
       "cpu": [
         "x64"
       ],
@@ -154,9 +217,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.7.11.tgz",
-      "integrity": "sha512-dHfLFVSrw/v5X5lkwp0Vl7+NFpEeEYKfMG2DpdFJnnG1RgHQZngZxCaBagFoaJGykRpd2DYF1AeuXBFrAUAXfw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.8.5.tgz",
+      "integrity": "sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg==",
       "cpu": [
         "arm"
       ],
@@ -167,9 +230,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.7.11.tgz",
-      "integrity": "sha512-7xGEfPPbmVJWcY2Nzqo11B9Nfxs+BAsiiaY/OcT4aaTDdykKeCjvKMQJA3KXCtZ1AtiC9ljyGLi+BfUwdulY5A==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.8.5.tgz",
+      "integrity": "sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww==",
       "cpu": [
         "arm64"
       ],
@@ -180,9 +243,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-x64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.7.11.tgz",
-      "integrity": "sha512-vUKI3JrREMQsXX8q0Eq5zX2FlYCKWMmLiCyyJNfZK0Uyf14RBg9VtB3ObQ41b4swYh2EWaltasWVe93Y8+KDng==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.8.5.tgz",
+      "integrity": "sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ==",
       "cpu": [
         "x64"
       ],
@@ -193,9 +256,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-win32-x64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.7.11.tgz",
-      "integrity": "sha512-BJwkHlSUgtB+Ei52Ai32M1AOMerSlzyIGA/KC4dAGL+GGwVMdwG8HGCOA2TxP3KjhbgDPMYkv7bt/NmOmRIFng==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.8.5.tgz",
+      "integrity": "sha512-4wvrf5BgnR8RpogHhtpCPJMKBmvyZPhhUtEwMJbXh0ni2BucpfF07jlmyM11zRqQ2XIq6PbC2j7W7UCCcm1rRQ==",
       "cpu": [
         "x64"
       ],
@@ -211,13 +274,13 @@
       "integrity": "sha512-KRoB7eSd1Md9NFWjkUyUODPnE1LBLGLQ0KGO0RCsOD5Bf1vkC01+I873yvDqYWmfYk0vk2wWlp41m0pEsg9HzA=="
     },
     "node_modules/@mischnic/json-sourcemap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
-      "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.1.tgz",
+      "integrity": "sha512-iA7+tyVqfrATAIsIRWQG+a7ZLLD0VaOCKV2Wd/v4mqIU3J9c4jx9p7S0nw1XH3gJCKNBOOwACOPYYSUu9pgT+w==",
       "dev": true,
       "dependencies": {
-        "@lezer/common": "^0.15.7",
-        "@lezer/lr": "^0.15.4",
+        "@lezer/common": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
         "json5": "^2.2.1"
       },
       "engines": {
@@ -303,21 +366,21 @@
       ]
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.9.3.tgz",
-      "integrity": "sha512-JjJK8dq39/UO/MWI/4SCbB1t/qgpQRFnFDetAAAezQ8oN++b24u1fkMDa/xqQGjbuPmGeTds5zxGgYs7id7PYg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.10.0.tgz",
+      "integrity": "sha512-pn8McDCuS02/D9jSo9QUTIv3tBQLlJl0PD4FvrndORXLAIFGoQR7jO4lxTSJB/eVBXwqKNVIR7WpB4sjsnBFyg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/graph": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/graph": "3.0.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -325,15 +388,15 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.9.3.tgz",
-      "integrity": "sha512-Bj/H2uAJJSXtysG7E/x4EgTrE2hXmm7td/bc97K8M9N7+vQjxf7xb0ebgqe84ePVMkj4MVQSMEJkEucXVx4b0Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.10.0.tgz",
+      "integrity": "sha512-4FzZpMTAAEFE65+O+Cf7f5kLLWRCiA+04IJdDYyQG5YzW1WujKXzrbh8B6tSSlw712dsQ/cUqNW4O0Q3FFKrfw==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "lmdb": "2.7.11"
+        "@parcel/fs": "2.10.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/utils": "2.10.0",
+        "lmdb": "2.8.5"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -343,13 +406,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.10.0"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.9.3.tgz",
-      "integrity": "sha512-z7yTyD6h3dvduaFoHpNqur74/2yDWL++33rjQjIjCaXREBN6dKHoMGMizzo/i4vbiI1p9dDox2FIDEHCMQxqdA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.10.0.tgz",
+      "integrity": "sha512-hHp457tddXEWrOgHHaA/NtkOhOAyt4mpBUzhnPbWDONLu5xeg1mu1Jffiu2rlw5xajhphrUFDWyJW0/xq1815g==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -363,16 +426,16 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.9.3.tgz",
-      "integrity": "sha512-jz3t4/ICMsHEqgiTmv5i1DJva2k5QRpZlBELVxfY+QElJTVe8edKJ0TiKcBxh2hx7sm4aUigGmp7JiqqHRRYmA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.10.0.tgz",
+      "integrity": "sha512-TXjosh5+kNN4lxENeIZ/2ZFQKWXpXlOoHhJbW4cGPXBMHxm0eimVpnFpD8xbWxg7VCcWzbEaUTp20GQ153X+9A==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3"
+        "@parcel/plugin": "2.10.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -380,71 +443,72 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.9.3.tgz",
-      "integrity": "sha512-tqN5tF7QnVABDZAu76co5E6N8mA9n8bxiWdK4xYyINYFIEHgX172oRTqXTnhEMjlMrdmASxvnGlbaPBaVnrCTw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.10.0.tgz",
+      "integrity": "sha512-7Ucd+KNEC08To2NrduC/yIHBN5ayedBoiuI5OVrDeKvyqUnI1S1HRqPF3DsrM8pC2PIdnwJgoOviRXwJemW28A==",
       "dev": true,
       "dependencies": {
-        "@parcel/bundler-default": "2.9.3",
-        "@parcel/compressor-raw": "2.9.3",
-        "@parcel/namer-default": "2.9.3",
-        "@parcel/optimizer-css": "2.9.3",
-        "@parcel/optimizer-htmlnano": "2.9.3",
-        "@parcel/optimizer-image": "2.9.3",
-        "@parcel/optimizer-svgo": "2.9.3",
-        "@parcel/optimizer-swc": "2.9.3",
-        "@parcel/packager-css": "2.9.3",
-        "@parcel/packager-html": "2.9.3",
-        "@parcel/packager-js": "2.9.3",
-        "@parcel/packager-raw": "2.9.3",
-        "@parcel/packager-svg": "2.9.3",
-        "@parcel/reporter-dev-server": "2.9.3",
-        "@parcel/resolver-default": "2.9.3",
-        "@parcel/runtime-browser-hmr": "2.9.3",
-        "@parcel/runtime-js": "2.9.3",
-        "@parcel/runtime-react-refresh": "2.9.3",
-        "@parcel/runtime-service-worker": "2.9.3",
-        "@parcel/transformer-babel": "2.9.3",
-        "@parcel/transformer-css": "2.9.3",
-        "@parcel/transformer-html": "2.9.3",
-        "@parcel/transformer-image": "2.9.3",
-        "@parcel/transformer-js": "2.9.3",
-        "@parcel/transformer-json": "2.9.3",
-        "@parcel/transformer-postcss": "2.9.3",
-        "@parcel/transformer-posthtml": "2.9.3",
-        "@parcel/transformer-raw": "2.9.3",
-        "@parcel/transformer-react-refresh-wrap": "2.9.3",
-        "@parcel/transformer-svg": "2.9.3"
+        "@parcel/bundler-default": "2.10.0",
+        "@parcel/compressor-raw": "2.10.0",
+        "@parcel/namer-default": "2.10.0",
+        "@parcel/optimizer-css": "2.10.0",
+        "@parcel/optimizer-htmlnano": "2.10.0",
+        "@parcel/optimizer-image": "2.10.0",
+        "@parcel/optimizer-svgo": "2.10.0",
+        "@parcel/optimizer-swc": "2.10.0",
+        "@parcel/packager-css": "2.10.0",
+        "@parcel/packager-html": "2.10.0",
+        "@parcel/packager-js": "2.10.0",
+        "@parcel/packager-raw": "2.10.0",
+        "@parcel/packager-svg": "2.10.0",
+        "@parcel/packager-wasm": "2.10.0",
+        "@parcel/reporter-dev-server": "2.10.0",
+        "@parcel/resolver-default": "2.10.0",
+        "@parcel/runtime-browser-hmr": "2.10.0",
+        "@parcel/runtime-js": "2.10.0",
+        "@parcel/runtime-react-refresh": "2.10.0",
+        "@parcel/runtime-service-worker": "2.10.0",
+        "@parcel/transformer-babel": "2.10.0",
+        "@parcel/transformer-css": "2.10.0",
+        "@parcel/transformer-html": "2.10.0",
+        "@parcel/transformer-image": "2.10.0",
+        "@parcel/transformer-js": "2.10.0",
+        "@parcel/transformer-json": "2.10.0",
+        "@parcel/transformer-postcss": "2.10.0",
+        "@parcel/transformer-posthtml": "2.10.0",
+        "@parcel/transformer-raw": "2.10.0",
+        "@parcel/transformer-react-refresh-wrap": "2.10.0",
+        "@parcel/transformer-svg": "2.10.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.10.0"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.9.3.tgz",
-      "integrity": "sha512-4KlM1Zr/jpsqWuMXr2zmGsaOUs1zMMFh9vfCNKRZkptf+uk8I3sugHbNdo+F5B+4e2yMuOEb1zgAmvJLeuH6ww==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-8jvLhLC2503HIBphJe/C1qL3bfiTSw6WgIDH0e7B8EL0v7v2JYnlTZ8o9myf+bMAxzwNLiZ2uEDCri9EWbi4tQ==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/graph": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/package-manager": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/profiler": "2.9.3",
+        "@parcel/cache": "2.10.0",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/events": "2.10.0",
+        "@parcel/fs": "2.10.0",
+        "@parcel/graph": "3.0.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/package-manager": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/profiler": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
+        "@parcel/workers": "2.10.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -465,9 +529,9 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.9.3.tgz",
-      "integrity": "sha512-6jxBdyB3D7gP4iE66ghUGntWt2v64E6EbD4AetZk+hNJpgudOOPsKTovcMi/i7I4V0qD7WXSF4tvkZUoac0jwA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.10.0.tgz",
+      "integrity": "sha512-ibr+sUZLc0MW75b+nThOa6YEi9QXTNYbUNCo067mtMIfhKNYTx24DaiGzDWgy1Yv49eucBaQ4u7gFI2Qa98uIA==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -482,9 +546,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.9.3.tgz",
-      "integrity": "sha512-K0Scx+Bx9f9p1vuShMzNwIgiaZUkxEnexaKYHYemJrM7pMAqxIuIqhnvwurRCsZOVLUJPDDNJ626cWTc5vIq+A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.10.0.tgz",
+      "integrity": "sha512-mhykJBnP3BPMI6A9hLZmTtmNHZuE+HGzsF6vzmA2YBuU3/BGlQUmxdObsmwQ1O24eq0EfJVwTM+R/bdu+/nFrA==",
       "dev": true,
       "engines": {
         "node": ">= 12.0.0"
@@ -495,16 +559,16 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.9.3.tgz",
-      "integrity": "sha512-/PrRKgCRw22G7rNPSpgN3Q+i2nIkZWuvIOAdMG4KWXC4XLp8C9jarNaWd5QEQ75amjhQSl3oUzABzkdCtkKrgg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.10.0.tgz",
+      "integrity": "sha512-so39KdZ4o7tDekeuuQfQdbfTUvldUtzvIsuUtJMqxVOVJRZr9VjieR9GbeFhqRmi9fM5oYdzQn4lbduKdAtANA==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs-search": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/rust": "2.10.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.9.3"
+        "@parcel/workers": "2.10.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -514,26 +578,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
-      }
-    },
-    "node_modules/@parcel/fs-search": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.9.3.tgz",
-      "integrity": "sha512-nsNz3bsOpwS+jphcd+XjZL3F3PDq9lik0O8HPm5f6LYkqKWT+u/kgQzA8OkAHCR3q96LGiHxUywHPEBc27vI4Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
+        "@parcel/core": "^2.10.0"
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.9.3.tgz",
-      "integrity": "sha512-3LmRJmF8+OprAr6zJT3X2s8WAhLKkrhi6RsFlMWHifGU5ED1PFcJWFbOwJvSjcAhMQJP0fErcFIK1Ludv3Vm3g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.0.0.tgz",
+      "integrity": "sha512-8Lussud6gWRM3Mysu+veBRsBdSlWgkM8y7PvF8AiRwEY2eiVxZ3Rgh8o9KJau3B8R8q+lyCaUElYpbnUT6Bkiw==",
       "dev": true,
       "dependencies": {
         "nullthrows": "^1.1.1"
@@ -546,30 +597,14 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/hash": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.9.3.tgz",
-      "integrity": "sha512-qlH5B85XLzVAeijgKPjm1gQu35LoRYX/8igsjnN8vOlbc3O8BYAUIutU58fbHbtE8MJPbxQQUw7tkTjeoujcQQ==",
-      "dev": true,
-      "dependencies": {
-        "xxhash-wasm": "^0.4.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/logger": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.9.3.tgz",
-      "integrity": "sha512-5FNBszcV6ilGFcijEOvoNVG6IUJGsnMiaEnGQs7Fvc1dktTjEddnoQbIYhcSZL63wEmzBZOgkT5yDMajJ/41jw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.10.0.tgz",
+      "integrity": "sha512-rDa48czGBZA313scvSEkuHSOQiGdoYLaWqInZBKtl0zke3qrgTFNG4b173H6IFdNq5KmKjafBxaV5jG87i4Gww==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3"
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/events": "2.10.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -580,9 +615,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.9.3.tgz",
-      "integrity": "sha512-/Q4X8F2aN8UNjAJrQ5NfK2OmZf6shry9DqetUSEndQ0fHonk78WKt6LT0zSKEBEW/bB/bXk6mNMsCup6L8ibjQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.10.0.tgz",
+      "integrity": "sha512-fuOuFglNANegE2nqVURwOJ/HzKM28O0hqy120Gl0NTbCAFbG34WCFxfkmVio8fondD4NcZcDj5GGv5P5TWcTIg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -596,18 +631,18 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.9.3.tgz",
-      "integrity": "sha512-1ynFEcap48/Ngzwwn318eLYpLUwijuuZoXQPCsEQ21OOIOtfhFQJaPwXTsw6kRitshKq76P2aafE0BioGSqxcA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.10.0.tgz",
+      "integrity": "sha512-N1IF6A8Y2fYz0BteU9IkhPQGezLA3cKkoSxoIOTiUf2LZPpUIuCGEAB1IgaUVNdAeMVsGw3UrdEYZg4xdMovEg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -615,15 +650,16 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.0.3.tgz",
-      "integrity": "sha512-AjxNcZVHHJoNT/A99PKIdFtwvoze8PAiC3yz8E/dRggrDIOboUEodeQYV5Aq++aK76uz/iOP0tST2T8A5rhb1A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.1.0.tgz",
+      "integrity": "sha512-0KBdWIXCpnDzjoZgc1qHhgxtNe5CZ4r4+Iht+LExacXwG1A1O5qKLQE1bBAgcjqkgv1iglVuMx0kVe9G8oob8A==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/fs": "2.10.0",
+        "@parcel/rust": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1",
         "semver": "^7.5.2"
       },
@@ -636,22 +672,22 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.9.3.tgz",
-      "integrity": "sha512-RK1QwcSdWDNUsFvuLy0hgnYKtPQebzCb0vPPzqs6LhL+vqUu9utOyRycGaQffHCkHVQP6zGlN+KFssd7YtFGhA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.10.0.tgz",
+      "integrity": "sha512-D7hFYjJpudlbSgMlzwSbSguLehwGe4vJrQ4s83jj7z0UlHd74Vir9fd9LQTPuUErgs2SOQIPxFwLGqR6Hi+mOg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.10.0",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -659,12 +695,12 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.9.3.tgz",
-      "integrity": "sha512-9g/KBck3c6DokmJfvJ5zpHFBiCSolaGrcsTGx8C3YPdCTVTI9P1TDCwUxvAr4LjpcIRSa82wlLCI+nF6sSgxKA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.10.0.tgz",
+      "integrity": "sha512-uYmluYpyyVumY7d/aHkGnFVLzOHoGqzVF9os/PkqVOnGEQ3qQibO3Hl9neTtm2GEUgeOfq1lrXLEfpW/k3qG1w==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
+        "@parcel/plugin": "2.10.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -672,7 +708,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -748,42 +784,43 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.9.3.tgz",
-      "integrity": "sha512-530YzthE7kmecnNhPbkAK+26yQNt69pfJrgE0Ev0BZaM1Wu2+33nki7o8qvkTkikhPrurEJLGIXt1qKmbKvCbA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.10.0.tgz",
+      "integrity": "sha512-uR/nd3kRxiQuPxB0nP5WLlydTUwRHcpFPAY0iV12cyjCQs+MaZHrhwoDO8kWVaT7jN7WXKYcSIHeP1kvR0HEQw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3"
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
+        "@parcel/utils": "2.10.0",
+        "@parcel/workers": "2.10.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.10.0"
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.9.3.tgz",
-      "integrity": "sha512-ytQS0wY5JJhWU4mL0wfhYDUuHcfuw+Gy2+JcnTm1t1AZXHlOTbU6EzRWNqBShsgXjvdrQQXizAe3B6GFFlFJVQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.10.0.tgz",
+      "integrity": "sha512-2IXClEpjlafidKAiOh/+amdDWOHGtA4Sil/3flmhLkjNFh7z2bGTYodO5xvC3Umw6N11fPNL1Wch1jn54fMO1g==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "svgo": "^2.4.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -859,21 +896,21 @@
       }
     },
     "node_modules/@parcel/optimizer-swc": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.9.3.tgz",
-      "integrity": "sha512-GQINNeqtdpL1ombq/Cpwi6IBk02wKJ/JJbYbyfHtk8lxlq13soenpwOlzJ5T9D2fdG+FUhai9NxpN5Ss4lNoAg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.10.0.tgz",
+      "integrity": "sha512-yq17TG6uyzIbiouK57AngJa6rVwfJ8hPzgc2lqZ9LJxDX07t/5Z+k/+aq4Izy+7kQNR8kH+4asWaMXReSsXmNQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.10.0",
         "@swc/core": "^1.3.36",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -881,18 +918,18 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.9.3.tgz",
-      "integrity": "sha512-NH6omcNTEupDmW4Lm1e4NUYBjdqkURxgZ4CNESESInHJe6tblVhNB8Rpr1ar7zDar7cly9ILr8P6N3Ei7bTEjg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.10.0.tgz",
+      "integrity": "sha512-BBUhwgX2Rz92SqGCyYp5Du4UEzm/bjrSSoeLtuRRevWKTVXhgHGbqcAlZmICoxb1lZGpn8x+pEivWd3w+5M7iA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/node-resolver-core": "3.0.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/fs": "2.10.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/node-resolver-core": "3.1.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
+        "@parcel/workers": "2.10.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -903,24 +940,24 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.10.0"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.9.3.tgz",
-      "integrity": "sha512-mePiWiYZOULY6e1RdAIJyRoYqXqGci0srOaVZYaP7mnrzvJgA63kaZFFsDiEWghunQpMUuUjM2x/vQVHzxmhKQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.10.0.tgz",
+      "integrity": "sha512-BY1PoPPOngiJ6gFD+mUQ6YZvwDxlth8oCU9328T8kFwhmA4qL6pfIxNPI1I53Ig5f38tf1nhFkHACDCbs4MxaQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -928,20 +965,20 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.9.3.tgz",
-      "integrity": "sha512-0Ex+O0EaZf9APNERRNGgGto02hFJ6f5RQEvRWBK55WAV1rXeU+kpjC0c0qZvnUaUtXfpWMsEBkevJCwDkUMeMg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.10.0.tgz",
+      "integrity": "sha512-EtxQwuQXQ6zrPRG9/pIdIcvuDCzBEsAnjN9kZ+XuxEYGoReX7weN4oALA6gCnw3w7U4cq6+VR1R08F6Cd8T2MQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -949,22 +986,23 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.9.3.tgz",
-      "integrity": "sha512-V5xwkoE3zQ3R+WqAWhA1KGQ791FvJeW6KonOlMI1q76Djjgox68hhObqcLu66AmYNhR2R/wUpkP18hP2z8dSFw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.10.0.tgz",
+      "integrity": "sha512-9r1pv8GScZzgGempexikym9d1aehTAp0DxK71LUxBT0os9Br+nJOtV4wmJWnHapt4r108d75DcgtytdVM5nuqA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -972,16 +1010,16 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.9.3.tgz",
-      "integrity": "sha512-oPQTNoYanQ2DdJyL61uPYK2py83rKOT8YVh2QWAx0zsSli6Kiy64U3+xOCYWgDVCrHw9+9NpQMuAdSiFg4cq8g==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.10.0.tgz",
+      "integrity": "sha512-fk1XGqMP38uyWC1Jqg8/Mp1x0dLxfd9GnmLHQCUZ0OSQLwF9Nqpow1WR4tC8juxYNK5haGqKyL9X5pVN4KLNYQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3"
+        "@parcel/plugin": "2.10.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -989,19 +1027,36 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.9.3.tgz",
-      "integrity": "sha512-p/Ya6UO9DAkaCUFxfFGyeHZDp9YPAlpdnh1OChuwqSFOXFjjeXuoK4KLT+ZRalVBo2Jo8xF70oKMZw4MVvaL7Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.10.0.tgz",
+      "integrity": "sha512-+vXXZwENinz/N2m04tH5BDSc8Zv7XNd/fsXZ3BAcEWmYpiTHBYMgbIy+fsdQb1tpFwku7CezthHFDsXejyNtrg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/packager-wasm": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.10.0.tgz",
+      "integrity": "sha512-G/OsV9Xpyu1D/mTwazw4FkWlFotcFMaRmejmc6km3+qjaFxMubRBLCNMCvGw2lDIhA40qz/DpZS/kblB/FGSPA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/plugin": "2.10.0"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1009,12 +1064,12 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.9.3.tgz",
-      "integrity": "sha512-qN85Gqr2GMuxX1dT1mnuO9hOcvlEv1lrYrCxn7CJN2nUhbwcfG+LEvcrCzCOJ6XtIHm+ZBV9h9p7FfoPLvpw+g==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.10.0.tgz",
+      "integrity": "sha512-FaWchkYJxLOohNNb3ah9R/9gckew+iGOzcGZ1bUtLGc/Dwz1mTVeaAanqOjlZ6C5FCe9lMctkH7h0eQsJ0mlVQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.9.3"
+        "@parcel/types": "2.10.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -1025,13 +1080,13 @@
       }
     },
     "node_modules/@parcel/profiler": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.9.3.tgz",
-      "integrity": "sha512-pyHc9lw8VZDfgZoeZWZU9J0CVEv1Zw9O5+e0DJPDPHuXJYr72ZAOhbljtU3owWKAeW+++Q2AZWkbUGEOjI/e6g==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.10.0.tgz",
+      "integrity": "sha512-SGkslseYA5TQOb8Z7gepi7YiIv3uH4BYAM9nwduMZrRZENcICbgTh1Pb+dp10y+6k9hFFH748eHtxJqSWARDBw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/events": "2.10.0",
         "chrome-trace-event": "^1.0.2"
       },
       "engines": {
@@ -1043,20 +1098,20 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.9.3.tgz",
-      "integrity": "sha512-pZiEvQpuXFuQBafMHxkDmwH8CnnK9sWHwa3bSbsnt385aUahtE8dpY0LKt+K1zfB6degKoczN6aWVj9WycQuZQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.10.0.tgz",
+      "integrity": "sha512-+OtZUdmHFgNY8+w3/U7dEZKMTtIFh7EiFw5VelKIGdvJrZNa9j7vbFuZziK6zUW2uopCk4qsDinn6Rfi7M16KA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1064,17 +1119,17 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.9.3.tgz",
-      "integrity": "sha512-s6eboxdLEtRSvG52xi9IiNbcPKC0XMVmvTckieue2EqGDbDcaHQoHmmwkk0rNq0/Z/UxelGcQXoIYC/0xq3ykQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.10.0.tgz",
+      "integrity": "sha512-1dMkVgbfx+AxRVjzX5on3LOY8Vhsr4wuwQdLhmN1kAveTNWUYBPSVzIt5ZPVj3Cmpwpaonj7tHkZ2YujaNWHQg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3"
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1082,19 +1137,19 @@
       }
     },
     "node_modules/@parcel/reporter-tracer": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.9.3.tgz",
-      "integrity": "sha512-9cXpKWk0m6d6d+4+TlAdOe8XIPaFEIKGWMWG+5SFAQE08u3olet4PSvd49F4+ZZo5ftRE7YI3j6xNbXvJT8KGw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.10.0.tgz",
+      "integrity": "sha512-mlxF3ozH6Kys4hewG1Bze1q8wHJL1ue276Qek9xPJly8ed08wU7rPGZF0vz8fJfKT8vx+nGvnKFXYiHjF+w6bg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1102,17 +1157,17 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.9.3.tgz",
-      "integrity": "sha512-8ESJk1COKvDzkmOnppNXoDamNMlYVIvrKc2RuFPmp8nKVj47R6NwMgvwxEaatyPzvkmyTpq5RvG9I3HFc+r4Cw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.10.0.tgz",
+      "integrity": "sha512-KWtKrmjf/CAyZkk+SSwHhMMwN6cjJJRtUSLCvwbrlevd0onRl3erUdVYrJrNB5X+N8ylCO6Vb0wCyMegOo/OwQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/node-resolver-core": "3.0.3",
-        "@parcel/plugin": "2.9.3"
+        "@parcel/node-resolver-core": "3.1.0",
+        "@parcel/plugin": "2.10.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1120,17 +1175,17 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.9.3.tgz",
-      "integrity": "sha512-EgiDIDrVAWpz7bOzWXqVinQkaFjLwT34wsonpXAbuI7f7r00d52vNAQC9AMu+pTijA3gyKoJ+Q4NWPMZf7ACDA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.10.0.tgz",
+      "integrity": "sha512-x22HHUAFuhycE/NGowkEaR7zeZsp8PcViHkmuNkSvLboe8PJvq4BFpnd+RUj+o8EjN31p+8K2pFqS1hYAmtdwg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3"
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1138,19 +1193,19 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.9.3.tgz",
-      "integrity": "sha512-EvIy+qXcKnB5qxHhe96zmJpSAViNVXHfQI5RSdZ2a7CPwORwhTI+zPNT9sb7xb/WwFw/WuTTgzT40b41DceU6Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.10.0.tgz",
+      "integrity": "sha512-AyDY+tQ9jiip6YsDGbaw7Azj60qG4fWNniUMIRMsywKQZOySLpfMNGHUcwDkV8j1NTve87Cwr2EzMOMnQHaUsQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1158,19 +1213,19 @@
       }
     },
     "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.9.3.tgz",
-      "integrity": "sha512-XBgryZQIyCmi6JwEfMUCmINB3l1TpTp9a2iFxmYNpzHlqj4Ve0saKaqWOVRLvC945ZovWIBzcSW2IYqWKGtbAA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.10.0.tgz",
+      "integrity": "sha512-hmiK9i6iitdjfcCaI0888+pecQHA0dzf6wMKnwtJsYQxCv2TrwXPsSOMHjkKr1K3ALXi8vlauG4K0Rm7c+vfdw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1178,18 +1233,31 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.9.3.tgz",
-      "integrity": "sha512-qLJLqv1mMdWL7gyh8aKBFFAuEiJkhUUgLKpdn6eSfH/R7kTtb76WnOwqUrhvEI9bZFUM/8Pa1bzJnPpqSOM+Sw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.10.0.tgz",
+      "integrity": "sha512-vi84PwAsyPI1P/5FTt1uNKjH1NGizQRdS4CmjBMz+VBT6GVuXMgZ9iQy3OYC8MsiyHlyG7mScftI74RWqw1DDg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/rust": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.10.0.tgz",
+      "integrity": "sha512-9J7riqPI8mVlFSDphK9kVUH8nFQgeMbO/95Ycf4vaEOVE1ICQo1h18WHAy2DndmL1uSd/UTimirrP6yLt/I3KA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1209,15 +1277,15 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.9.3.tgz",
-      "integrity": "sha512-pURtEsnsp3h6tOBDuzh9wRvVtw4PgIlqwAArIWdrG7iwqOUYv9D8ME4+ePWEu7MQWAp58hv9pTJtqWv4T+Sq8A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.10.0.tgz",
+      "integrity": "sha512-XwlzHt7WPfueFlwl/bXItopgZ6ILSPzl5OmPeytHrM2TanymeLjJ1y3vxwY1C1BhNlrTwPHcf9U8aiuVSpE8RQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.10.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -1225,7 +1293,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1233,22 +1301,22 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.9.3.tgz",
-      "integrity": "sha512-duWMdbEBBPjg3fQdXF16iWIdThetDZvCs2TpUD7xOlXH6kR0V5BJy8ONFT15u1RCqIV9hSNGaS3v3I9YRNY5zQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.10.0.tgz",
+      "integrity": "sha512-hITticpUE/qilpsTc7HQP04qhXwyUSKGZKgcFnvf8+BJO/LoclbVK1nzbR61eYl5Jhj1XB67p3tCt5fSvPhOsQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.10.0",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.16.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1256,14 +1324,14 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.9.3.tgz",
-      "integrity": "sha512-0NU4omcHzFXA1seqftAXA2KNZaMByoKaNdXnLgBgtCGDiYvOcL+6xGHgY6pw9LvOh5um10KI5TxSIMILoI7VtA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.10.0.tgz",
+      "integrity": "sha512-rc8YKjB+bE7yGHOf674CSzW8ii+m5caBo4akdRIUdhEHJS4FnSwxYIZlMcfV9pZM4Tj5PFMZyrlAHad6YrO8aA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1273,7 +1341,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1281,35 +1349,36 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.9.3.tgz",
-      "integrity": "sha512-7CEe35RaPadQzLIuxzTtIxnItvOoy46hcbXtOdDt6lmVa4omuOygZYRIya2lsGIP4JHvAaALMb5nt99a1uTwJg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.10.0.tgz",
+      "integrity": "sha512-qbNyAJvzqdO/OnHhCOoPAZN5aBD/xphyXvDNI0Fb3UPEr5MQtAnzv2lS1I63s4rKpphBntWj7nEIAio6s7c5bw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
+        "@parcel/workers": "2.10.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.10.0"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.9.3.tgz",
-      "integrity": "sha512-Z2MVVg5FYcPOfxlUwxqb5l9yjTMEqE3KI3zq2MBRUme6AV07KxLmCDF23b6glzZlHWQUE8MXzYCTAkOPCcPz+Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.10.0.tgz",
+      "integrity": "sha512-39ZNnje8dlmME1ipjFyAFHyhHaGCwZZpXYN9SCTl/+AnjZLamnmVFkesgBbrRSBRQixRG1VwCvrWsjLLeLkTUg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/utils": "2.10.0",
+        "@parcel/workers": "2.10.0",
         "@swc/helpers": "^0.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1",
@@ -1318,28 +1387,28 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.10.0"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.9.3.tgz",
-      "integrity": "sha512-yNL27dbOLhkkrjaQjiQ7Im9VOxmkfuuSNSmS0rA3gEjVcm07SLKRzWkAaPnyx44Lb6bzyOTWwVrb9aMmxgADpA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.10.0.tgz",
+      "integrity": "sha512-4G6ZIt7IYu1l3BlsL55Hi3869X6KHE0CHybWf364h5ZUmzo3Xpc5i7cziQX+IhWDo1qn1jiziOPGY85LXlo8ug==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
+        "@parcel/plugin": "2.10.0",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1347,15 +1416,15 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.9.3.tgz",
-      "integrity": "sha512-HoDvPqKzhpmvMmHqQhDnt8F1vH61m6plpGiYaYnYv2Om4HHi5ZIq9bO+9QLBnTKfaZ7ndYSefTKOxTYElg7wyw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.10.0.tgz",
+      "integrity": "sha512-Xhz+MHr9Q31d3u3hsBOtmFGEQx7FsNbTumGpqIqaGkDDq4IIMKbEwyrpkmf7/02kyxcbwr6uaBqnMHm55j10sQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -1363,7 +1432,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1371,13 +1440,13 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.9.3.tgz",
-      "integrity": "sha512-2fQGgrzRmaqbWf3y2/T6xhqrNjzqMMKksqJzvc8TMfK6f2kg3Ddjv158eaSW2JdkV39aY7tvAOn5f1uzo74BMA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.10.0.tgz",
+      "integrity": "sha512-kmz8Yip5hh2y3bfA76mC2QtI9VHdS7k5dV96/yjar0CkLHJnr33Jh7MTfuCN+01nVU20Tn3YMqEMQ/ErPVJwlg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1386,7 +1455,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1394,16 +1463,16 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.9.3.tgz",
-      "integrity": "sha512-oqdPzMC9QzWRbY9J6TZEqltknjno+dY24QWqf8ondmdF2+W+/2mRDu59hhCzQrqUHgTq4FewowRZmSfpzHxwaQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.10.0.tgz",
+      "integrity": "sha512-1tR58kqzTh4baLq/++bp84H2lhOoAz8cJeJykgsYImva7aRWcjlTppNKjBF6Ef8etIRMPZOozTdbS53VdQ9IbA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3"
+        "@parcel/plugin": "2.10.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1411,18 +1480,18 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.9.3.tgz",
-      "integrity": "sha512-cb9NyU6oJlDblFIlzqIE8AkvRQVGl2IwJNKwD4PdE7Y6sq2okGEPG4hOw3k/Y9JVjM4/2pUORqvjSRhWwd9oVQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.10.0.tgz",
+      "integrity": "sha512-4ab1tiwUA2XznTh/eb/IVKEA+Ynkbqc5sgNuobf1MLKF82FXTUT5szVshff/ODpwublvVBD3YbXlapxV5xyFvA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1430,14 +1499,14 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.9.3.tgz",
-      "integrity": "sha512-ypmE+dzB09IMCdEAkOsSxq1dEIm2A3h67nAFz4qbfHbwNgXBUuy/jB3ZMwXN/cO0f7SBh/Ap8Jhq6vmGqB5tWw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.10.0.tgz",
+      "integrity": "sha512-qEZFk4gxyVNhm2V8R3YLo9qCyYNVBySWmZLjmwuhLLmAE+r0qGebc9oXyo7C6ML5d/4Tfj6NriCOeX+HMhPVxw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -1446,7 +1515,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.9.3"
+        "parcel": "^2.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1454,31 +1523,31 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.9.3.tgz",
-      "integrity": "sha512-NSNY8sYtRhvF1SqhnIGgGvJocyWt1K8Tnw5cVepm0g38ywtX6mwkBvMkmeehXkII4mSUn+frD9wGsydTunezvA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.10.0.tgz",
+      "integrity": "sha512-iDFVvgN+jK02GY++V+WY3WuNTM6CGDPToGfL31/Sgf6/1PzT7kL6uXJ6+859u8wkTIrtkWD2XyTNkKJJ8jPwgg==",
       "dev": true,
       "dependencies": {
-        "@parcel/cache": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/package-manager": "2.9.3",
+        "@parcel/cache": "2.10.0",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/fs": "2.10.0",
+        "@parcel/package-manager": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/workers": "2.9.3",
+        "@parcel/workers": "2.10.0",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.9.3.tgz",
-      "integrity": "sha512-cesanjtj/oLehW8Waq9JFPmAImhoiHX03ihc3JTWkrvJYSbD7wYKCDgPAM3JiRAqvh1LZ6P699uITrYWNoRLUg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.10.0.tgz",
+      "integrity": "sha512-8qx9caJTjli6UKpKlcPjdSBblkwTc+BnIsSK3/7fX7kbtHLmEkQH/RWZbbOJItHbnzlsmaDJTfS7j6rrcFw2Pw==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/markdown-ansi": "2.9.3",
+        "@parcel/codeframe": "2.10.0",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/markdown-ansi": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.0",
         "nullthrows": "^1.1.1"
@@ -1492,9 +1561,9 @@
       }
     },
     "node_modules/@parcel/watcher": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.2.0.tgz",
-      "integrity": "sha512-71S4TF+IMyAn24PK4KSkdKtqJDR3zRzb0HE3yXpacItqTM7XfF2f5q9NEGLEVl0dAaBAGfNwDCjH120y25F6Tg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.3.0.tgz",
+      "integrity": "sha512-pW7QaFiL11O0BphO+bq3MgqeX/INAk9jgBldVDYjlQPO4VddoZnF22TcF9onMhnLVHuNqBJeRf+Fj7eezi/+rQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1511,22 +1580,24 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.2.0",
-        "@parcel/watcher-darwin-arm64": "2.2.0",
-        "@parcel/watcher-darwin-x64": "2.2.0",
-        "@parcel/watcher-linux-arm-glibc": "2.2.0",
-        "@parcel/watcher-linux-arm64-glibc": "2.2.0",
-        "@parcel/watcher-linux-arm64-musl": "2.2.0",
-        "@parcel/watcher-linux-x64-glibc": "2.2.0",
-        "@parcel/watcher-linux-x64-musl": "2.2.0",
-        "@parcel/watcher-win32-arm64": "2.2.0",
-        "@parcel/watcher-win32-x64": "2.2.0"
+        "@parcel/watcher-android-arm64": "2.3.0",
+        "@parcel/watcher-darwin-arm64": "2.3.0",
+        "@parcel/watcher-darwin-x64": "2.3.0",
+        "@parcel/watcher-freebsd-x64": "2.3.0",
+        "@parcel/watcher-linux-arm-glibc": "2.3.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.3.0",
+        "@parcel/watcher-linux-arm64-musl": "2.3.0",
+        "@parcel/watcher-linux-x64-glibc": "2.3.0",
+        "@parcel/watcher-linux-x64-musl": "2.3.0",
+        "@parcel/watcher-win32-arm64": "2.3.0",
+        "@parcel/watcher-win32-ia32": "2.3.0",
+        "@parcel/watcher-win32-x64": "2.3.0"
       }
     },
     "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.2.0.tgz",
-      "integrity": "sha512-nU2wh00CTQT9rr1TIKTjdQ9lAGYpmz6XuKw0nAwAN+S2A5YiD55BK1u+E5WMCT8YOIDe/n6gaj4o/Bi9294SSQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.3.0.tgz",
+      "integrity": "sha512-f4o9eA3dgk0XRT3XhB0UWpWpLnKgrh1IwNJKJ7UJek7eTYccQ8LR7XUWFKqw6aEq5KUNlCcGvSzKqSX/vtWVVA==",
       "cpu": [
         "arm64"
       ],
@@ -1544,9 +1615,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.2.0.tgz",
-      "integrity": "sha512-cJl0UZDcodciy3TDMomoK/Huxpjlkkim3SyMgWzjovHGOZKNce9guLz2dzuFwfObBFCjfznbFMIvAZ5syXotYw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.3.0.tgz",
+      "integrity": "sha512-mKY+oijI4ahBMc/GygVGvEdOq0L4DxhYgwQqYAz/7yPzuGi79oXrZG52WdpGA1wLBPrYb0T8uBaGFo7I6rvSKw==",
       "cpu": [
         "arm64"
       ],
@@ -1564,9 +1635,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.2.0.tgz",
-      "integrity": "sha512-QI77zxaGrCV1StKcoRYfsUfmUmvPMPfQrubkBBy5XujV2fwaLgZivQOTQMBgp5K2+E19u1ufpspKXAPqSzpbyg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.3.0.tgz",
+      "integrity": "sha512-20oBj8LcEOnLE3mgpy6zuOq8AplPu9NcSSSfyVKgfOhNAc4eF4ob3ldj0xWjGGbOF7Dcy1Tvm6ytvgdjlfUeow==",
       "cpu": [
         "x64"
       ],
@@ -1583,10 +1654,30 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.3.0.tgz",
+      "integrity": "sha512-7LftKlaHunueAEiojhCn+Ef2CTXWsLgTl4hq0pkhkTBFI3ssj2bJXmH2L67mKpiAD5dz66JYk4zS66qzdnIOgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.2.0.tgz",
-      "integrity": "sha512-I2GPBcAXazPzabCmfsa3HRRW+MGlqxYd8g8RIueJU+a4o5nyNZDz0CR1cu0INT0QSQXEZV7w6UE8Hz9CF8u3Pg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.3.0.tgz",
+      "integrity": "sha512-1apPw5cD2xBv1XIHPUlq0cO6iAaEUQ3BcY0ysSyD9Kuyw4MoWm1DV+W9mneWI+1g6OeP6dhikiFE6BlU+AToTQ==",
       "cpu": [
         "arm"
       ],
@@ -1604,9 +1695,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.2.0.tgz",
-      "integrity": "sha512-St5mlfp+2lS9AmgixUqfwJa/DwVmTCJxC1HcOubUTz6YFOKIlkHCeUa1Bxi4E/tR/HSez8+heXHL8HQkJ4Bd8g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.3.0.tgz",
+      "integrity": "sha512-mQ0gBSQEiq1k/MMkgcSB0Ic47UORZBmWoAWlMrTW6nbAGoLZP+h7AtUM7H3oDu34TBFFvjy4JCGP43JlylkTQA==",
       "cpu": [
         "arm64"
       ],
@@ -1624,9 +1715,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.2.0.tgz",
-      "integrity": "sha512-jS+qfhhoOBVWwMLP65MaG8xdInMK30pPW8wqTCg2AAuVJh5xepMbzkhHJ4zURqHiyY3EiIRuYu4ONJKCxt8iqA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.3.0.tgz",
+      "integrity": "sha512-LXZAExpepJew0Gp8ZkJ+xDZaTQjLHv48h0p0Vw2VMFQ8A+RKrAvpFuPVCVwKJCr5SE+zvaG+Etg56qXvTDIedw==",
       "cpu": [
         "arm64"
       ],
@@ -1644,9 +1735,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.2.0.tgz",
-      "integrity": "sha512-xJvJ7R2wJdi47WZBFS691RDOWvP1j/IAs3EXaWVhDI8FFITbWrWaln7KoNcR0Y3T+ZwimFY/cfb0PNht1q895g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.3.0.tgz",
+      "integrity": "sha512-P7Wo91lKSeSgMTtG7CnBS6WrA5otr1K7shhSjKHNePVmfBHDoAOHYRXgUmhiNfbcGk0uMCHVcdbfxtuiZCHVow==",
       "cpu": [
         "x64"
       ],
@@ -1664,9 +1755,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.2.0.tgz",
-      "integrity": "sha512-D+NMpgr23a+RI5mu8ZPKWy7AqjBOkURFDgP5iIXXEf/K3hm0jJ3ogzi0Ed2237B/CdYREimCgXyeiAlE/FtwyA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.3.0.tgz",
+      "integrity": "sha512-+kiRE1JIq8QdxzwoYY+wzBs9YbJ34guBweTK8nlzLKimn5EQ2b2FSC+tAOpq302BuIMjyuUGvBiUhEcLIGMQ5g==",
       "cpu": [
         "x64"
       ],
@@ -1684,9 +1775,9 @@
       }
     },
     "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.2.0.tgz",
-      "integrity": "sha512-z225cPn3aygJsyVUOWwfyW+fY0Tvk7N3XCOl66qUPFxpbuXeZuiuuJemmtm8vxyqa3Ur7peU/qJxrpC64aeI7Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.3.0.tgz",
+      "integrity": "sha512-35gXCnaz1AqIXpG42evcoP2+sNL62gZTMZne3IackM+6QlfMcJLy3DrjuL6Iks7Czpd3j4xRBzez3ADCj1l7Aw==",
       "cpu": [
         "arm64"
       ],
@@ -1703,10 +1794,30 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.3.0.tgz",
+      "integrity": "sha512-FJS/IBQHhRpZ6PiCjFt1UAcPr0YmCLHRbTc00IBTrelEjlmmgIVLeOx4MSXzx2HFEy5Jo5YdhGpxCuqCyDJ5ow==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.2.0.tgz",
-      "integrity": "sha512-JqGW0RJ61BkKx+yYzIURt9s53P7xMVbv0uxYPzAXLBINGaFmkIKSuUPyBVfy8TMbvp93lvF4SPBNDzVRJfvgOw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.3.0.tgz",
+      "integrity": "sha512-dLx+0XRdMnVI62kU3wbXvbIRhLck4aE28bIGKbRGS7BJNt54IIj9+c/Dkqb+7DJEbHUZAX1bwaoM8PqVlHJmCA==",
       "cpu": [
         "x64"
       ],
@@ -1724,16 +1835,16 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.9.3.tgz",
-      "integrity": "sha512-zRrDuZJzTevrrwElYosFztgldhqW6G9q5zOeQXfVQFkkEJCNfg36ixeiofKRU8uu2x+j+T6216mhMNB6HiuY+w==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.10.0.tgz",
+      "integrity": "sha512-PILDag4aW7G9w2AvYvBsMHe/NRCoOt+L7HJzp6UIvy6ssbafH/8fzdGjSpA99GXzC5AXpAHVt8RXhGMXmMP6QA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/profiler": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/profiler": "2.10.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -1744,15 +1855,19 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.9.3"
+        "@parcel/core": "^2.10.0"
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.67.tgz",
-      "integrity": "sha512-9DROjzfAEt0xt0CDkOYsWpkUPyne8fl5ggWGon049678BOM7p0R0dmaalZGAsKatG5vYP1IWSKWsKhJIubDCsQ==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.92.tgz",
+      "integrity": "sha512-vx0vUrf4YTEw59njOJ46Ha5i0cZTMYdRHQ7KXU29efN1MxcmJH2RajWLPlvQarOP1ab9iv9cApD7SMchDyx2vA==",
       "dev": true,
       "hasInstallScript": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.1",
+        "@swc/types": "^0.1.5"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -1761,16 +1876,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.67",
-        "@swc/core-darwin-x64": "1.3.67",
-        "@swc/core-linux-arm-gnueabihf": "1.3.67",
-        "@swc/core-linux-arm64-gnu": "1.3.67",
-        "@swc/core-linux-arm64-musl": "1.3.67",
-        "@swc/core-linux-x64-gnu": "1.3.67",
-        "@swc/core-linux-x64-musl": "1.3.67",
-        "@swc/core-win32-arm64-msvc": "1.3.67",
-        "@swc/core-win32-ia32-msvc": "1.3.67",
-        "@swc/core-win32-x64-msvc": "1.3.67"
+        "@swc/core-darwin-arm64": "1.3.92",
+        "@swc/core-darwin-x64": "1.3.92",
+        "@swc/core-linux-arm-gnueabihf": "1.3.92",
+        "@swc/core-linux-arm64-gnu": "1.3.92",
+        "@swc/core-linux-arm64-musl": "1.3.92",
+        "@swc/core-linux-x64-gnu": "1.3.92",
+        "@swc/core-linux-x64-musl": "1.3.92",
+        "@swc/core-win32-arm64-msvc": "1.3.92",
+        "@swc/core-win32-ia32-msvc": "1.3.92",
+        "@swc/core-win32-x64-msvc": "1.3.92"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -1782,9 +1897,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.67.tgz",
-      "integrity": "sha512-zCT2mCkOBVNf5uJDcQ3A9KDoO1OEaGdfjsRTZTo7sejDd9AXLfJg+xgyCBBrK2jNS/uWcT21IvSv3LqKp4K8pA==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.92.tgz",
+      "integrity": "sha512-v7PqZUBtIF6Q5Cp48gqUiG8zQQnEICpnfNdoiY3xjQAglCGIQCjJIDjreZBoeZQZspB27lQN4eZ43CX18+2SnA==",
       "cpu": [
         "arm64"
       ],
@@ -1798,9 +1913,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.67.tgz",
-      "integrity": "sha512-hXTVsfTatPEec5gFVyjGj3NccKZsYj/OXyHn6XA+l3Q76lZzGm2ISHdku//XNwXu8OmJ0HhS7LPsC4XXwxXQhg==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.92.tgz",
+      "integrity": "sha512-Q3XIgQfXyxxxms3bPN+xGgvwk0TtG9l89IomApu+yTKzaIIlf051mS+lGngjnh9L0aUiCp6ICyjDLtutWP54fw==",
       "cpu": [
         "x64"
       ],
@@ -1814,9 +1929,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.67.tgz",
-      "integrity": "sha512-l8AKL0RkDL5FRTeWMmjoz9zvAc37amxC+0rheaNwE+gZya7ObyNjnIYz5FwN+3y+z6JFU7LS2x/5f6iwruv6pg==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.92.tgz",
+      "integrity": "sha512-tnOCoCpNVXC+0FCfG84PBZJyLlz0Vfj9MQhyhCvlJz9hQmvpf8nTdKH7RHrOn8VfxtUBLdVi80dXgIFgbvl7qA==",
       "cpu": [
         "arm"
       ],
@@ -1830,9 +1945,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.67.tgz",
-      "integrity": "sha512-S8zOB1AXEpb7kmtgMaFNeLAj01VOky4B0RNZ+uJWigdrDiFT67FeZzNHUNmNSOU0QM79G+Lie/xD/beqEw0vDg==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.92.tgz",
+      "integrity": "sha512-lFfGhX32w8h1j74Iyz0Wv7JByXIwX11OE9UxG+oT7lG0RyXkF4zKyxP8EoxfLrDXse4Oop434p95e3UNC3IfCw==",
       "cpu": [
         "arm64"
       ],
@@ -1846,9 +1961,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.67.tgz",
-      "integrity": "sha512-Fex8J8ASrt13pmOr2xWh41tEeKWwXYGk3sV8L/aGHiYtIJEUi2f+RtMx3jp7LIdOD8pQptor7i5WBlfR9jhp8A==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.92.tgz",
+      "integrity": "sha512-rOZtRcLj57MSAbiecMsqjzBcZDuaCZ8F6l6JDwGkQ7u1NYR57cqF0QDyU7RKS1Jq27Z/Vg21z5cwqoH5fLN+Sg==",
       "cpu": [
         "arm64"
       ],
@@ -1862,9 +1977,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.67.tgz",
-      "integrity": "sha512-9bz9/bMphrv5vDg0os/d8ve0QgFpDzJgZgHUaHiGwcmfnlgdOSAaYJLIvWdcGTjZuQeV4L0m+iru357D9TXEzA==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.92.tgz",
+      "integrity": "sha512-qptoMGnBL6v89x/Qpn+l1TH1Y0ed+v0qhNfAEVzZvCvzEMTFXphhlhYbDdpxbzRmCjH6GOGq7Y+xrWt9T1/ARg==",
       "cpu": [
         "x64"
       ],
@@ -1878,9 +1993,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.67.tgz",
-      "integrity": "sha512-ED0H6oLvQmhgo9zs8usmEA/lcZPGTu7K9og9K871b7HhHX0h/R+Xg2pb5KD7S/GyUHpfuopxjVROm+h6X1jMUA==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.92.tgz",
+      "integrity": "sha512-g2KrJ43bZkCZHH4zsIV5ErojuV1OIpUHaEyW1gf7JWKaFBpWYVyubzFPvPkjcxHGLbMsEzO7w/NVfxtGMlFH/Q==",
       "cpu": [
         "x64"
       ],
@@ -1894,9 +2009,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.67.tgz",
-      "integrity": "sha512-J1yFDLgPFeRtA8t5E159OXX+ww1gbkFg70yr4OP7EsOkOD1uMkuTf9yK/woHfsaVJlUYjJHzw7MkUIEgQBucqQ==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.92.tgz",
+      "integrity": "sha512-3MCRGPAYDoQ8Yyd3WsCMc8eFSyKXY5kQLyg/R5zEqA0uthomo0m0F5/fxAJMZGaSdYkU1DgF73ctOWOf+Z/EzQ==",
       "cpu": [
         "arm64"
       ],
@@ -1910,9 +2025,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.67.tgz",
-      "integrity": "sha512-bK11/KtasewqHxzkjKUBXRE9MSAidbZCxrgJUd49bItG2N/DHxkwMYu8Xkh5VDHdTYWv/2idYtf/VM9Yi+53qw==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.92.tgz",
+      "integrity": "sha512-zqTBKQhgfWm73SVGS8FKhFYDovyRl1f5dTX1IwSKynO0qHkRCqJwauFJv/yevkpJWsI2pFh03xsRs9HncTQKSA==",
       "cpu": [
         "ia32"
       ],
@@ -1926,9 +2041,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.67.tgz",
-      "integrity": "sha512-GxzUU3+NA3cPcYxCxtfSQIS2ySD7Z8IZmKTVaWA9GOUQbKLyCE8H5js31u39+0op/1gNgxOgYFDoj2lUyvLCqw==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.92.tgz",
+      "integrity": "sha512-41bE66ddr9o/Fi1FBh0sHdaKdENPTuDpv1IFHxSg0dJyM/jX8LbkjnpdInYXHBxhcLVAPraVRrNsC4SaoPw2Pg==",
       "cpu": [
         "x64"
       ],
@@ -1941,14 +2056,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/@swc/counter": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.2.tgz",
+      "integrity": "sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==",
+      "dev": true
+    },
     "node_modules/@swc/helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.3.tgz",
+      "integrity": "sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
+      "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
+      "dev": true
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
@@ -2014,9 +2141,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "dev": true,
       "funding": [
         {
@@ -2033,10 +2160,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001503",
-        "electron-to-chromium": "^1.4.431",
-        "node-releases": "^2.0.12",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2055,9 +2182,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001511",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001511.tgz",
-      "integrity": "sha512-NaWPJawcoedlghN4P7bDNeADD7K+rZaY6V8ZcME7PkEZo/nfOg+lnrUgRWiKbNxcQ4/toFKSxnS4WdbyPZnKkw==",
+      "version": "1.0.30001547",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001547.tgz",
+      "integrity": "sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA==",
       "dev": true,
       "funding": [
         {
@@ -2136,14 +2263,14 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "dependencies": {
-        "import-fresh": "^3.2.1",
+        "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.0.0",
+        "parse-json": "^5.2.0",
         "path-type": "^4.0.0"
       },
       "engines": {
@@ -2151,6 +2278,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/css-select": {
@@ -2392,9 +2527,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.447",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.447.tgz",
-      "integrity": "sha512-sxX0LXh+uL41hSJsujAN86PjhrV/6c79XmpY0TvjZStV6VxIgarf8SRkUoUTuYmFcZQTemsoqo8qXOGw5npWfw==",
+      "version": "1.4.552",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.552.tgz",
+      "integrity": "sha512-qMPzA5TEuOAbLFmbpNvO4qkBRe2B5dAxl6H4KxqRNy9cvBeHT2EyzecX0bumBfRhHN8cQJrx6NPd0AAoCCPKQw==",
       "dev": true
     },
     "node_modules/entities": {
@@ -2458,9 +2593,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.23.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2642,9 +2777,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.21.2.tgz",
-      "integrity": "sha512-6GoGcH4CHGLN6hq5lcmtkKxolXw8nsmgoaYsy6AilwH0vS0GUpKlgFegaf7LmDZqxawjV6LmymQFBZYe+sS45w==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.22.0.tgz",
+      "integrity": "sha512-+z0qvwRVzs4XGRXelnWRNwqsXUx8k3bSkbP8vD42kYKSk3z9OM2P3e/gagT7ei/gwh8DTS80LZOFZV6lm8Z8Fg==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -2657,20 +2792,21 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.21.2",
-        "lightningcss-darwin-x64": "1.21.2",
-        "lightningcss-linux-arm-gnueabihf": "1.21.2",
-        "lightningcss-linux-arm64-gnu": "1.21.2",
-        "lightningcss-linux-arm64-musl": "1.21.2",
-        "lightningcss-linux-x64-gnu": "1.21.2",
-        "lightningcss-linux-x64-musl": "1.21.2",
-        "lightningcss-win32-x64-msvc": "1.21.2"
+        "lightningcss-darwin-arm64": "1.22.0",
+        "lightningcss-darwin-x64": "1.22.0",
+        "lightningcss-freebsd-x64": "1.22.0",
+        "lightningcss-linux-arm-gnueabihf": "1.22.0",
+        "lightningcss-linux-arm64-gnu": "1.22.0",
+        "lightningcss-linux-arm64-musl": "1.22.0",
+        "lightningcss-linux-x64-gnu": "1.22.0",
+        "lightningcss-linux-x64-musl": "1.22.0",
+        "lightningcss-win32-x64-msvc": "1.22.0"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.21.2.tgz",
-      "integrity": "sha512-uh2+MUWWc6rQpMfD3YoIRRxxRaUdhJSI3zeq7EXWQI4pDFcgV8LxGq6yfyMB0cJT1Hh55elQHM3Y139YJrhHFQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.22.0.tgz",
+      "integrity": "sha512-aH2be3nNny+It5YEVm8tBSSdRlBVWQV8m2oJ7dESiYRzyY/E/bQUe2xlw5caaMuhlM9aoTMtOH25yzMhir0qPg==",
       "cpu": [
         "arm64"
       ],
@@ -2688,9 +2824,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.21.2.tgz",
-      "integrity": "sha512-Qv+Tra9p+Lqw4o3XMrDOJBWz5HhNueFHPG+AZMatyQKyWIVKTxDtW9/J7J7J8I2PE26UeLhlQE26ych5PGAp4Q==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.22.0.tgz",
+      "integrity": "sha512-9KHRFA0Y6mNxRHeoQMp0YaI0R0O2kOgUlYPRjuasU4d+pI8NRhVn9bt0yX9VPs5ibWX1RbDViSPtGJvYYrfVAQ==",
       "cpu": [
         "x64"
       ],
@@ -2707,10 +2843,30 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.22.0.tgz",
+      "integrity": "sha512-xaYL3xperGwD85rQioDb52ozF3NAJb+9wrge3jD9lxGffplu0Mn35rXMptB8Uc2N9Mw1i3Bvl7+z1evlqVl7ww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.21.2.tgz",
-      "integrity": "sha512-83KqiPvvOuAocrUyuV+V3peLe5cfBZRHV312vSJq/OGluHzeg2meb36q73q1gIcz/qX9RdAcx6GlhZ/vwbGpnQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.22.0.tgz",
+      "integrity": "sha512-epQGvXIjOuxrZpMpMnRjK54ZqzhiHhCPLtHvw2fb6NeK2kK9YtF0wqmeTBiQ1AkbWfnnXGTstYaFNiadNK+StQ==",
       "cpu": [
         "arm"
       ],
@@ -2728,9 +2884,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.21.2.tgz",
-      "integrity": "sha512-YAFPWM8Wi2UXIf382aDGxx0/zxOROZ7ADTBi8coXmI5FjDqUjxypc4U9+o962oi3k/N3K6IaL2f/E172+Xj0vA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.22.0.tgz",
+      "integrity": "sha512-AArGtKSY4DGTA8xP8SDyNyKtpsUl1Rzq6FW4JomeyUQ4nBrR71uPChksTpj3gmWuGhZeRKLeCUI1DBid/zhChg==",
       "cpu": [
         "arm64"
       ],
@@ -2748,9 +2904,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.21.2.tgz",
-      "integrity": "sha512-dTIaIbOgo/mYzkEi2ESI9+ciZz7un8G0AxiM8E8lrkelm3lgTnSO/4fWaEfx+u9LsVM7dgAN5cfiDBQCr2koYA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.22.0.tgz",
+      "integrity": "sha512-RRraNgP8hnBPhInTTUdlFm+z16C/ghbxBG51Sw00hd7HUyKmEUKRozyc5od+/N6pOrX/bIh5vIbtMXIxsos0lg==",
       "cpu": [
         "arm64"
       ],
@@ -2768,9 +2924,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.21.2.tgz",
-      "integrity": "sha512-xFieDlPN2cfoVKVBg5XLyxvIAJPw2J3njlOFUQOJEDbLbp+qI8hgxqz34dlI/zZMq4Dmzroc7LPB/MengYjYHQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.22.0.tgz",
+      "integrity": "sha512-grdrhYGRi2KrR+bsXJVI0myRADqyA7ekprGxiuK5QRNkv7kj3Yq1fERDNyzZvjisHwKUi29sYMClscbtl+/Zpw==",
       "cpu": [
         "x64"
       ],
@@ -2788,9 +2944,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.21.2.tgz",
-      "integrity": "sha512-1w+oiZY3H1V/5FxpvtEUXHBZFuAPzUFoFolpDKNDphr9h9xPo3xc2eg3zuz96ia+tb2QmBB5S3QZrQ/dGGc8GA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.22.0.tgz",
+      "integrity": "sha512-t5f90X+iQUtIyR56oXIHMBUyQFX/zwmPt72E6Dane3P8KNGlkijTg2I75XVQS860gNoEFzV7Mm5ArRRA7u5CAQ==",
       "cpu": [
         "x64"
       ],
@@ -2808,9 +2964,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.21.2.tgz",
-      "integrity": "sha512-NzuZx5gH7H6Me7h88Boil0vhIqs5+kQ8K2B6ZYQAllj8yk0zCs4cqOLUxXmm6fiykRxCzdRPcEP8ZYvbBCcGgw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.22.0.tgz",
+      "integrity": "sha512-64HTDtOOZE9PUCZJiZZQpyqXBbdby1lnztBccnqh+NtbKxjnGzP92R2ngcgeuqMPecMNqNWxgoWgTGpC+yN5Sw==",
       "cpu": [
         "x64"
       ],
@@ -2834,43 +2990,34 @@
       "dev": true
     },
     "node_modules/lmdb": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.7.11.tgz",
-      "integrity": "sha512-x9bD4hVp7PFLUoELL8RglbNXhAMt5CYhkmss+CEau9KlNoilsTzNi9QDsPZb3KMpOGZXG6jmXhW3bBxE2XVztw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.8.5.tgz",
+      "integrity": "sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "msgpackr": "1.8.5",
-        "node-addon-api": "^4.3.0",
-        "node-gyp-build-optional-packages": "5.0.6",
-        "ordered-binary": "^1.4.0",
+        "msgpackr": "^1.9.5",
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build-optional-packages": "5.1.1",
+        "ordered-binary": "^1.4.1",
         "weak-lru-cache": "^1.2.2"
       },
       "bin": {
         "download-lmdb-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@lmdb/lmdb-darwin-arm64": "2.7.11",
-        "@lmdb/lmdb-darwin-x64": "2.7.11",
-        "@lmdb/lmdb-linux-arm": "2.7.11",
-        "@lmdb/lmdb-linux-arm64": "2.7.11",
-        "@lmdb/lmdb-linux-x64": "2.7.11",
-        "@lmdb/lmdb-win32-x64": "2.7.11"
-      }
-    },
-    "node_modules/lmdb/node_modules/msgpackr": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.5.tgz",
-      "integrity": "sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==",
-      "dev": true,
-      "optionalDependencies": {
-        "msgpackr-extract": "^3.0.1"
+        "@lmdb/lmdb-darwin-arm64": "2.8.5",
+        "@lmdb/lmdb-darwin-x64": "2.8.5",
+        "@lmdb/lmdb-linux-arm": "2.8.5",
+        "@lmdb/lmdb-linux-arm64": "2.8.5",
+        "@lmdb/lmdb-linux-x64": "2.8.5",
+        "@lmdb/lmdb-win32-x64": "2.8.5"
       }
     },
     "node_modules/lmdb/node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "dev": true
     },
     "node_modules/lru-cache": {
@@ -2907,9 +3054,9 @@
       }
     },
     "node_modules/msgpackr": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.5.tgz",
-      "integrity": "sha512-/IJ3cFSN6Ci3eG2wLhbFEL6GT63yEaoN/R5My2QkV6zro+OJaVRLPlwvxY7EtHYSmDlQpk8stvOQTL2qJFkDRg==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.9.tgz",
+      "integrity": "sha512-sbn6mioS2w0lq1O6PpGtsv6Gy8roWM+o3o4Sqjd6DudrL/nOugY+KyJUimoWzHnf9OkO0T6broHFnYE/R05t9A==",
       "dev": true,
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"
@@ -2956,20 +3103,32 @@
       "dev": true
     },
     "node_modules/node-gyp-build-optional-packages": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.6.tgz",
-      "integrity": "sha512-2ZJErHG4du9G3/8IWl/l9Bp5BBFy63rno5GVmjQijvTuUZKsl6g8RB4KH/x3NLcV5ZBb4GsXmAuTYr6dRml3Gw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
       "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
       "bin": {
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
+    "node_modules/node-gyp-build-optional-packages/node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "node_modules/nth-check": {
@@ -2991,28 +3150,28 @@
       "dev": true
     },
     "node_modules/ordered-binary": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.4.0.tgz",
-      "integrity": "sha512-EHQ/jk4/a9hLupIKxTfUsQRej1Yd/0QLQs3vGvIqg5ZtCYSzNhkzHoZc7Zf4e4kUlDaC3Uw8Q/1opOLNN2OKRQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.4.1.tgz",
+      "integrity": "sha512-9LtiGlPy982CsgxZvJGNNp2/NnrgEr6EAyN3iIEP3/8vd3YLgAZQHbQ75ZrkfBRGrNg37Dk3U6tuVb+B4Xfslg==",
       "dev": true
     },
     "node_modules/parcel": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.9.3.tgz",
-      "integrity": "sha512-2GTVocFkwblV/TIg9AmT7TI2fO4xdWkyN8aFUEVtiVNWt96GTR3FgQyHFValfCbcj1k9Xf962Ws2hYXYUr9k1Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.10.0.tgz",
+      "integrity": "sha512-YJmWEsiv1ClpPcJiWkr3gFj40sRvfeK89GGGwJjpzQMQsBmN6h6OHrSkByx0jrsPIvdsOIccU702upYpRAypuw==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.9.3",
-        "@parcel/core": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/package-manager": "2.9.3",
-        "@parcel/reporter-cli": "2.9.3",
-        "@parcel/reporter-dev-server": "2.9.3",
-        "@parcel/reporter-tracer": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/config-default": "2.10.0",
+        "@parcel/core": "2.10.0",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/events": "2.10.0",
+        "@parcel/fs": "2.10.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/package-manager": "2.10.0",
+        "@parcel/reporter-cli": "2.10.0",
+        "@parcel/reporter-dev-server": "2.10.0",
+        "@parcel/reporter-tracer": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0"
@@ -3191,9 +3350,9 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3313,9 +3472,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "node_modules/type-fest": {
@@ -3331,9 +3490,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3344,9 +3503,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "funding": [
         {
@@ -3388,12 +3547,6 @@
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true
     },
-    "node_modules/xxhash-wasm": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
-      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==",
-      "dev": true
-    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -3403,28 +3556,81 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.22.5"
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "dependencies": {
@@ -3481,59 +3687,59 @@
       }
     },
     "@lezer/common": {
-      "version": "0.15.12",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
-      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.1.0.tgz",
+      "integrity": "sha512-XPIN3cYDXsoJI/oDWoR2tD++juVrhgIago9xyKhZ7IhGlzdDM9QgC8D8saKNCz5pindGcznFr2HBSsEQSWnSjw==",
       "dev": true
     },
     "@lezer/lr": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
-      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.13.tgz",
+      "integrity": "sha512-RLAbau/4uSzKgIKj96mI5WUtG1qtiR0Frn0Ei9zhPj8YOkHM+1Bb8SgdVvmR/aWJCFIzjo2KFnDiRZ75Xf5NdQ==",
       "dev": true,
       "requires": {
-        "@lezer/common": "^0.15.0"
+        "@lezer/common": "^1.0.0"
       }
     },
     "@lmdb/lmdb-darwin-arm64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.7.11.tgz",
-      "integrity": "sha512-r6+vYq2vKzE+vgj/rNVRMwAevq0+ZR9IeMFIqcSga+wMtMdXQ27KqQ7uS99/yXASg29bos7yHP3yk4x6Iio0lw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.8.5.tgz",
+      "integrity": "sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-darwin-x64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.7.11.tgz",
-      "integrity": "sha512-jhj1aB4K8ycRL1HOQT5OtzlqOq70jxUQEWRN9Gqh3TIDN30dxXtiHi6EWF516tzw6v2+3QqhDMJh8O6DtTGG8Q==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.8.5.tgz",
+      "integrity": "sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-linux-arm": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.7.11.tgz",
-      "integrity": "sha512-dHfLFVSrw/v5X5lkwp0Vl7+NFpEeEYKfMG2DpdFJnnG1RgHQZngZxCaBagFoaJGykRpd2DYF1AeuXBFrAUAXfw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.8.5.tgz",
+      "integrity": "sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-linux-arm64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.7.11.tgz",
-      "integrity": "sha512-7xGEfPPbmVJWcY2Nzqo11B9Nfxs+BAsiiaY/OcT4aaTDdykKeCjvKMQJA3KXCtZ1AtiC9ljyGLi+BfUwdulY5A==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.8.5.tgz",
+      "integrity": "sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-linux-x64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.7.11.tgz",
-      "integrity": "sha512-vUKI3JrREMQsXX8q0Eq5zX2FlYCKWMmLiCyyJNfZK0Uyf14RBg9VtB3ObQ41b4swYh2EWaltasWVe93Y8+KDng==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.8.5.tgz",
+      "integrity": "sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-win32-x64": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.7.11.tgz",
-      "integrity": "sha512-BJwkHlSUgtB+Ei52Ai32M1AOMerSlzyIGA/KC4dAGL+GGwVMdwG8HGCOA2TxP3KjhbgDPMYkv7bt/NmOmRIFng==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.8.5.tgz",
+      "integrity": "sha512-4wvrf5BgnR8RpogHhtpCPJMKBmvyZPhhUtEwMJbXh0ni2BucpfF07jlmyM11zRqQ2XIq6PbC2j7W7UCCcm1rRQ==",
       "dev": true,
       "optional": true
     },
@@ -3543,13 +3749,13 @@
       "integrity": "sha512-KRoB7eSd1Md9NFWjkUyUODPnE1LBLGLQ0KGO0RCsOD5Bf1vkC01+I873yvDqYWmfYk0vk2wWlp41m0pEsg9HzA=="
     },
     "@mischnic/json-sourcemap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
-      "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.1.tgz",
+      "integrity": "sha512-iA7+tyVqfrATAIsIRWQG+a7ZLLD0VaOCKV2Wd/v4mqIU3J9c4jx9p7S0nw1XH3gJCKNBOOwACOPYYSUu9pgT+w==",
       "dev": true,
       "requires": {
-        "@lezer/common": "^0.15.7",
-        "@lezer/lr": "^0.15.4",
+        "@lezer/common": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
         "json5": "^2.2.1"
       }
     },
@@ -3596,108 +3802,109 @@
       "optional": true
     },
     "@parcel/bundler-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.9.3.tgz",
-      "integrity": "sha512-JjJK8dq39/UO/MWI/4SCbB1t/qgpQRFnFDetAAAezQ8oN++b24u1fkMDa/xqQGjbuPmGeTds5zxGgYs7id7PYg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.10.0.tgz",
+      "integrity": "sha512-pn8McDCuS02/D9jSo9QUTIv3tBQLlJl0PD4FvrndORXLAIFGoQR7jO4lxTSJB/eVBXwqKNVIR7WpB4sjsnBFyg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/graph": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/graph": "3.0.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/cache": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.9.3.tgz",
-      "integrity": "sha512-Bj/H2uAJJSXtysG7E/x4EgTrE2hXmm7td/bc97K8M9N7+vQjxf7xb0ebgqe84ePVMkj4MVQSMEJkEucXVx4b0Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.10.0.tgz",
+      "integrity": "sha512-4FzZpMTAAEFE65+O+Cf7f5kLLWRCiA+04IJdDYyQG5YzW1WujKXzrbh8B6tSSlw712dsQ/cUqNW4O0Q3FFKrfw==",
       "dev": true,
       "requires": {
-        "@parcel/fs": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "lmdb": "2.7.11"
+        "@parcel/fs": "2.10.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/utils": "2.10.0",
+        "lmdb": "2.8.5"
       }
     },
     "@parcel/codeframe": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.9.3.tgz",
-      "integrity": "sha512-z7yTyD6h3dvduaFoHpNqur74/2yDWL++33rjQjIjCaXREBN6dKHoMGMizzo/i4vbiI1p9dDox2FIDEHCMQxqdA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.10.0.tgz",
+      "integrity": "sha512-hHp457tddXEWrOgHHaA/NtkOhOAyt4mpBUzhnPbWDONLu5xeg1mu1Jffiu2rlw5xajhphrUFDWyJW0/xq1815g==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/compressor-raw": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.9.3.tgz",
-      "integrity": "sha512-jz3t4/ICMsHEqgiTmv5i1DJva2k5QRpZlBELVxfY+QElJTVe8edKJ0TiKcBxh2hx7sm4aUigGmp7JiqqHRRYmA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.10.0.tgz",
+      "integrity": "sha512-TXjosh5+kNN4lxENeIZ/2ZFQKWXpXlOoHhJbW4cGPXBMHxm0eimVpnFpD8xbWxg7VCcWzbEaUTp20GQ153X+9A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3"
+        "@parcel/plugin": "2.10.0"
       }
     },
     "@parcel/config-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.9.3.tgz",
-      "integrity": "sha512-tqN5tF7QnVABDZAu76co5E6N8mA9n8bxiWdK4xYyINYFIEHgX172oRTqXTnhEMjlMrdmASxvnGlbaPBaVnrCTw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.10.0.tgz",
+      "integrity": "sha512-7Ucd+KNEC08To2NrduC/yIHBN5ayedBoiuI5OVrDeKvyqUnI1S1HRqPF3DsrM8pC2PIdnwJgoOviRXwJemW28A==",
       "dev": true,
       "requires": {
-        "@parcel/bundler-default": "2.9.3",
-        "@parcel/compressor-raw": "2.9.3",
-        "@parcel/namer-default": "2.9.3",
-        "@parcel/optimizer-css": "2.9.3",
-        "@parcel/optimizer-htmlnano": "2.9.3",
-        "@parcel/optimizer-image": "2.9.3",
-        "@parcel/optimizer-svgo": "2.9.3",
-        "@parcel/optimizer-swc": "2.9.3",
-        "@parcel/packager-css": "2.9.3",
-        "@parcel/packager-html": "2.9.3",
-        "@parcel/packager-js": "2.9.3",
-        "@parcel/packager-raw": "2.9.3",
-        "@parcel/packager-svg": "2.9.3",
-        "@parcel/reporter-dev-server": "2.9.3",
-        "@parcel/resolver-default": "2.9.3",
-        "@parcel/runtime-browser-hmr": "2.9.3",
-        "@parcel/runtime-js": "2.9.3",
-        "@parcel/runtime-react-refresh": "2.9.3",
-        "@parcel/runtime-service-worker": "2.9.3",
-        "@parcel/transformer-babel": "2.9.3",
-        "@parcel/transformer-css": "2.9.3",
-        "@parcel/transformer-html": "2.9.3",
-        "@parcel/transformer-image": "2.9.3",
-        "@parcel/transformer-js": "2.9.3",
-        "@parcel/transformer-json": "2.9.3",
-        "@parcel/transformer-postcss": "2.9.3",
-        "@parcel/transformer-posthtml": "2.9.3",
-        "@parcel/transformer-raw": "2.9.3",
-        "@parcel/transformer-react-refresh-wrap": "2.9.3",
-        "@parcel/transformer-svg": "2.9.3"
+        "@parcel/bundler-default": "2.10.0",
+        "@parcel/compressor-raw": "2.10.0",
+        "@parcel/namer-default": "2.10.0",
+        "@parcel/optimizer-css": "2.10.0",
+        "@parcel/optimizer-htmlnano": "2.10.0",
+        "@parcel/optimizer-image": "2.10.0",
+        "@parcel/optimizer-svgo": "2.10.0",
+        "@parcel/optimizer-swc": "2.10.0",
+        "@parcel/packager-css": "2.10.0",
+        "@parcel/packager-html": "2.10.0",
+        "@parcel/packager-js": "2.10.0",
+        "@parcel/packager-raw": "2.10.0",
+        "@parcel/packager-svg": "2.10.0",
+        "@parcel/packager-wasm": "2.10.0",
+        "@parcel/reporter-dev-server": "2.10.0",
+        "@parcel/resolver-default": "2.10.0",
+        "@parcel/runtime-browser-hmr": "2.10.0",
+        "@parcel/runtime-js": "2.10.0",
+        "@parcel/runtime-react-refresh": "2.10.0",
+        "@parcel/runtime-service-worker": "2.10.0",
+        "@parcel/transformer-babel": "2.10.0",
+        "@parcel/transformer-css": "2.10.0",
+        "@parcel/transformer-html": "2.10.0",
+        "@parcel/transformer-image": "2.10.0",
+        "@parcel/transformer-js": "2.10.0",
+        "@parcel/transformer-json": "2.10.0",
+        "@parcel/transformer-postcss": "2.10.0",
+        "@parcel/transformer-posthtml": "2.10.0",
+        "@parcel/transformer-raw": "2.10.0",
+        "@parcel/transformer-react-refresh-wrap": "2.10.0",
+        "@parcel/transformer-svg": "2.10.0"
       }
     },
     "@parcel/core": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.9.3.tgz",
-      "integrity": "sha512-4KlM1Zr/jpsqWuMXr2zmGsaOUs1zMMFh9vfCNKRZkptf+uk8I3sugHbNdo+F5B+4e2yMuOEb1zgAmvJLeuH6ww==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-8jvLhLC2503HIBphJe/C1qL3bfiTSw6WgIDH0e7B8EL0v7v2JYnlTZ8o9myf+bMAxzwNLiZ2uEDCri9EWbi4tQ==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/graph": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/package-manager": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/profiler": "2.9.3",
+        "@parcel/cache": "2.10.0",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/events": "2.10.0",
+        "@parcel/fs": "2.10.0",
+        "@parcel/graph": "3.0.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/package-manager": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/profiler": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
+        "@parcel/workers": "2.10.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -3711,9 +3918,9 @@
       }
     },
     "@parcel/diagnostic": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.9.3.tgz",
-      "integrity": "sha512-6jxBdyB3D7gP4iE66ghUGntWt2v64E6EbD4AetZk+hNJpgudOOPsKTovcMi/i7I4V0qD7WXSF4tvkZUoac0jwA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.10.0.tgz",
+      "integrity": "sha512-ibr+sUZLc0MW75b+nThOa6YEi9QXTNYbUNCo067mtMIfhKNYTx24DaiGzDWgy1Yv49eucBaQ4u7gFI2Qa98uIA==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -3721,114 +3928,100 @@
       }
     },
     "@parcel/events": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.9.3.tgz",
-      "integrity": "sha512-K0Scx+Bx9f9p1vuShMzNwIgiaZUkxEnexaKYHYemJrM7pMAqxIuIqhnvwurRCsZOVLUJPDDNJ626cWTc5vIq+A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.10.0.tgz",
+      "integrity": "sha512-mhykJBnP3BPMI6A9hLZmTtmNHZuE+HGzsF6vzmA2YBuU3/BGlQUmxdObsmwQ1O24eq0EfJVwTM+R/bdu+/nFrA==",
       "dev": true
     },
     "@parcel/fs": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.9.3.tgz",
-      "integrity": "sha512-/PrRKgCRw22G7rNPSpgN3Q+i2nIkZWuvIOAdMG4KWXC4XLp8C9jarNaWd5QEQ75amjhQSl3oUzABzkdCtkKrgg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.10.0.tgz",
+      "integrity": "sha512-so39KdZ4o7tDekeuuQfQdbfTUvldUtzvIsuUtJMqxVOVJRZr9VjieR9GbeFhqRmi9fM5oYdzQn4lbduKdAtANA==",
       "dev": true,
       "requires": {
-        "@parcel/fs-search": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/rust": "2.10.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.9.3"
+        "@parcel/workers": "2.10.0"
       }
     },
-    "@parcel/fs-search": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.9.3.tgz",
-      "integrity": "sha512-nsNz3bsOpwS+jphcd+XjZL3F3PDq9lik0O8HPm5f6LYkqKWT+u/kgQzA8OkAHCR3q96LGiHxUywHPEBc27vI4Q==",
-      "dev": true
-    },
     "@parcel/graph": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.9.3.tgz",
-      "integrity": "sha512-3LmRJmF8+OprAr6zJT3X2s8WAhLKkrhi6RsFlMWHifGU5ED1PFcJWFbOwJvSjcAhMQJP0fErcFIK1Ludv3Vm3g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.0.0.tgz",
+      "integrity": "sha512-8Lussud6gWRM3Mysu+veBRsBdSlWgkM8y7PvF8AiRwEY2eiVxZ3Rgh8o9KJau3B8R8q+lyCaUElYpbnUT6Bkiw==",
       "dev": true,
       "requires": {
         "nullthrows": "^1.1.1"
       }
     },
-    "@parcel/hash": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.9.3.tgz",
-      "integrity": "sha512-qlH5B85XLzVAeijgKPjm1gQu35LoRYX/8igsjnN8vOlbc3O8BYAUIutU58fbHbtE8MJPbxQQUw7tkTjeoujcQQ==",
-      "dev": true,
-      "requires": {
-        "xxhash-wasm": "^0.4.2"
-      }
-    },
     "@parcel/logger": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.9.3.tgz",
-      "integrity": "sha512-5FNBszcV6ilGFcijEOvoNVG6IUJGsnMiaEnGQs7Fvc1dktTjEddnoQbIYhcSZL63wEmzBZOgkT5yDMajJ/41jw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.10.0.tgz",
+      "integrity": "sha512-rDa48czGBZA313scvSEkuHSOQiGdoYLaWqInZBKtl0zke3qrgTFNG4b173H6IFdNq5KmKjafBxaV5jG87i4Gww==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3"
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/events": "2.10.0"
       }
     },
     "@parcel/markdown-ansi": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.9.3.tgz",
-      "integrity": "sha512-/Q4X8F2aN8UNjAJrQ5NfK2OmZf6shry9DqetUSEndQ0fHonk78WKt6LT0zSKEBEW/bB/bXk6mNMsCup6L8ibjQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.10.0.tgz",
+      "integrity": "sha512-fuOuFglNANegE2nqVURwOJ/HzKM28O0hqy120Gl0NTbCAFbG34WCFxfkmVio8fondD4NcZcDj5GGv5P5TWcTIg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/namer-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.9.3.tgz",
-      "integrity": "sha512-1ynFEcap48/Ngzwwn318eLYpLUwijuuZoXQPCsEQ21OOIOtfhFQJaPwXTsw6kRitshKq76P2aafE0BioGSqxcA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.10.0.tgz",
+      "integrity": "sha512-N1IF6A8Y2fYz0BteU9IkhPQGezLA3cKkoSxoIOTiUf2LZPpUIuCGEAB1IgaUVNdAeMVsGw3UrdEYZg4xdMovEg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/node-resolver-core": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.0.3.tgz",
-      "integrity": "sha512-AjxNcZVHHJoNT/A99PKIdFtwvoze8PAiC3yz8E/dRggrDIOboUEodeQYV5Aq++aK76uz/iOP0tST2T8A5rhb1A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.1.0.tgz",
+      "integrity": "sha512-0KBdWIXCpnDzjoZgc1qHhgxtNe5CZ4r4+Iht+LExacXwG1A1O5qKLQE1bBAgcjqkgv1iglVuMx0kVe9G8oob8A==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/fs": "2.10.0",
+        "@parcel/rust": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1",
         "semver": "^7.5.2"
       }
     },
     "@parcel/optimizer-css": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.9.3.tgz",
-      "integrity": "sha512-RK1QwcSdWDNUsFvuLy0hgnYKtPQebzCb0vPPzqs6LhL+vqUu9utOyRycGaQffHCkHVQP6zGlN+KFssd7YtFGhA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.10.0.tgz",
+      "integrity": "sha512-D7hFYjJpudlbSgMlzwSbSguLehwGe4vJrQ4s83jj7z0UlHd74Vir9fd9LQTPuUErgs2SOQIPxFwLGqR6Hi+mOg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.10.0",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.16.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/optimizer-htmlnano": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.9.3.tgz",
-      "integrity": "sha512-9g/KBck3c6DokmJfvJ5zpHFBiCSolaGrcsTGx8C3YPdCTVTI9P1TDCwUxvAr4LjpcIRSa82wlLCI+nF6sSgxKA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.10.0.tgz",
+      "integrity": "sha512-uYmluYpyyVumY7d/aHkGnFVLzOHoGqzVF9os/PkqVOnGEQ3qQibO3Hl9neTtm2GEUgeOfq1lrXLEfpW/k3qG1w==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
+        "@parcel/plugin": "2.10.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -3891,26 +4084,27 @@
       }
     },
     "@parcel/optimizer-image": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.9.3.tgz",
-      "integrity": "sha512-530YzthE7kmecnNhPbkAK+26yQNt69pfJrgE0Ev0BZaM1Wu2+33nki7o8qvkTkikhPrurEJLGIXt1qKmbKvCbA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.10.0.tgz",
+      "integrity": "sha512-uR/nd3kRxiQuPxB0nP5WLlydTUwRHcpFPAY0iV12cyjCQs+MaZHrhwoDO8kWVaT7jN7WXKYcSIHeP1kvR0HEQw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3"
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
+        "@parcel/utils": "2.10.0",
+        "@parcel/workers": "2.10.0"
       }
     },
     "@parcel/optimizer-svgo": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.9.3.tgz",
-      "integrity": "sha512-ytQS0wY5JJhWU4mL0wfhYDUuHcfuw+Gy2+JcnTm1t1AZXHlOTbU6EzRWNqBShsgXjvdrQQXizAe3B6GFFlFJVQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.10.0.tgz",
+      "integrity": "sha512-2IXClEpjlafidKAiOh/+amdDWOHGtA4Sil/3flmhLkjNFh7z2bGTYodO5xvC3Umw6N11fPNL1Wch1jn54fMO1g==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "svgo": "^2.4.0"
       },
       "dependencies": {
@@ -3970,206 +4164,222 @@
       }
     },
     "@parcel/optimizer-swc": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.9.3.tgz",
-      "integrity": "sha512-GQINNeqtdpL1ombq/Cpwi6IBk02wKJ/JJbYbyfHtk8lxlq13soenpwOlzJ5T9D2fdG+FUhai9NxpN5Ss4lNoAg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.10.0.tgz",
+      "integrity": "sha512-yq17TG6uyzIbiouK57AngJa6rVwfJ8hPzgc2lqZ9LJxDX07t/5Z+k/+aq4Izy+7kQNR8kH+4asWaMXReSsXmNQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.10.0",
         "@swc/core": "^1.3.36",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/package-manager": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.9.3.tgz",
-      "integrity": "sha512-NH6omcNTEupDmW4Lm1e4NUYBjdqkURxgZ4CNESESInHJe6tblVhNB8Rpr1ar7zDar7cly9ILr8P6N3Ei7bTEjg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.10.0.tgz",
+      "integrity": "sha512-BBUhwgX2Rz92SqGCyYp5Du4UEzm/bjrSSoeLtuRRevWKTVXhgHGbqcAlZmICoxb1lZGpn8x+pEivWd3w+5M7iA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/node-resolver-core": "3.0.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/fs": "2.10.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/node-resolver-core": "3.1.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
+        "@parcel/workers": "2.10.0",
         "semver": "^7.5.2"
       }
     },
     "@parcel/packager-css": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.9.3.tgz",
-      "integrity": "sha512-mePiWiYZOULY6e1RdAIJyRoYqXqGci0srOaVZYaP7mnrzvJgA63kaZFFsDiEWghunQpMUuUjM2x/vQVHzxmhKQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.10.0.tgz",
+      "integrity": "sha512-BY1PoPPOngiJ6gFD+mUQ6YZvwDxlth8oCU9328T8kFwhmA4qL6pfIxNPI1I53Ig5f38tf1nhFkHACDCbs4MxaQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-html": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.9.3.tgz",
-      "integrity": "sha512-0Ex+O0EaZf9APNERRNGgGto02hFJ6f5RQEvRWBK55WAV1rXeU+kpjC0c0qZvnUaUtXfpWMsEBkevJCwDkUMeMg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.10.0.tgz",
+      "integrity": "sha512-EtxQwuQXQ6zrPRG9/pIdIcvuDCzBEsAnjN9kZ+XuxEYGoReX7weN4oALA6gCnw3w7U4cq6+VR1R08F6Cd8T2MQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       }
     },
     "@parcel/packager-js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.9.3.tgz",
-      "integrity": "sha512-V5xwkoE3zQ3R+WqAWhA1KGQ791FvJeW6KonOlMI1q76Djjgox68hhObqcLu66AmYNhR2R/wUpkP18hP2z8dSFw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.10.0.tgz",
+      "integrity": "sha512-9r1pv8GScZzgGempexikym9d1aehTAp0DxK71LUxBT0os9Br+nJOtV4wmJWnHapt4r108d75DcgtytdVM5nuqA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-raw": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.9.3.tgz",
-      "integrity": "sha512-oPQTNoYanQ2DdJyL61uPYK2py83rKOT8YVh2QWAx0zsSli6Kiy64U3+xOCYWgDVCrHw9+9NpQMuAdSiFg4cq8g==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.10.0.tgz",
+      "integrity": "sha512-fk1XGqMP38uyWC1Jqg8/Mp1x0dLxfd9GnmLHQCUZ0OSQLwF9Nqpow1WR4tC8juxYNK5haGqKyL9X5pVN4KLNYQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3"
+        "@parcel/plugin": "2.10.0"
       }
     },
     "@parcel/packager-svg": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.9.3.tgz",
-      "integrity": "sha512-p/Ya6UO9DAkaCUFxfFGyeHZDp9YPAlpdnh1OChuwqSFOXFjjeXuoK4KLT+ZRalVBo2Jo8xF70oKMZw4MVvaL7Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.10.0.tgz",
+      "integrity": "sha512-+vXXZwENinz/N2m04tH5BDSc8Zv7XNd/fsXZ3BAcEWmYpiTHBYMgbIy+fsdQb1tpFwku7CezthHFDsXejyNtrg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "posthtml": "^0.16.4"
       }
     },
-    "@parcel/plugin": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.9.3.tgz",
-      "integrity": "sha512-qN85Gqr2GMuxX1dT1mnuO9hOcvlEv1lrYrCxn7CJN2nUhbwcfG+LEvcrCzCOJ6XtIHm+ZBV9h9p7FfoPLvpw+g==",
+    "@parcel/packager-wasm": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.10.0.tgz",
+      "integrity": "sha512-G/OsV9Xpyu1D/mTwazw4FkWlFotcFMaRmejmc6km3+qjaFxMubRBLCNMCvGw2lDIhA40qz/DpZS/kblB/FGSPA==",
       "dev": true,
       "requires": {
-        "@parcel/types": "2.9.3"
+        "@parcel/plugin": "2.10.0"
+      }
+    },
+    "@parcel/plugin": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.10.0.tgz",
+      "integrity": "sha512-FaWchkYJxLOohNNb3ah9R/9gckew+iGOzcGZ1bUtLGc/Dwz1mTVeaAanqOjlZ6C5FCe9lMctkH7h0eQsJ0mlVQ==",
+      "dev": true,
+      "requires": {
+        "@parcel/types": "2.10.0"
       }
     },
     "@parcel/profiler": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.9.3.tgz",
-      "integrity": "sha512-pyHc9lw8VZDfgZoeZWZU9J0CVEv1Zw9O5+e0DJPDPHuXJYr72ZAOhbljtU3owWKAeW+++Q2AZWkbUGEOjI/e6g==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.10.0.tgz",
+      "integrity": "sha512-SGkslseYA5TQOb8Z7gepi7YiIv3uH4BYAM9nwduMZrRZENcICbgTh1Pb+dp10y+6k9hFFH748eHtxJqSWARDBw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/events": "2.10.0",
         "chrome-trace-event": "^1.0.2"
       }
     },
     "@parcel/reporter-cli": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.9.3.tgz",
-      "integrity": "sha512-pZiEvQpuXFuQBafMHxkDmwH8CnnK9sWHwa3bSbsnt385aUahtE8dpY0LKt+K1zfB6degKoczN6aWVj9WycQuZQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.10.0.tgz",
+      "integrity": "sha512-+OtZUdmHFgNY8+w3/U7dEZKMTtIFh7EiFw5VelKIGdvJrZNa9j7vbFuZziK6zUW2uopCk4qsDinn6Rfi7M16KA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
       }
     },
     "@parcel/reporter-dev-server": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.9.3.tgz",
-      "integrity": "sha512-s6eboxdLEtRSvG52xi9IiNbcPKC0XMVmvTckieue2EqGDbDcaHQoHmmwkk0rNq0/Z/UxelGcQXoIYC/0xq3ykQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.10.0.tgz",
+      "integrity": "sha512-1dMkVgbfx+AxRVjzX5on3LOY8Vhsr4wuwQdLhmN1kAveTNWUYBPSVzIt5ZPVj3Cmpwpaonj7tHkZ2YujaNWHQg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3"
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0"
       }
     },
     "@parcel/reporter-tracer": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.9.3.tgz",
-      "integrity": "sha512-9cXpKWk0m6d6d+4+TlAdOe8XIPaFEIKGWMWG+5SFAQE08u3olet4PSvd49F4+ZZo5ftRE7YI3j6xNbXvJT8KGw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.10.0.tgz",
+      "integrity": "sha512-mlxF3ozH6Kys4hewG1Bze1q8wHJL1ue276Qek9xPJly8ed08wU7rPGZF0vz8fJfKT8vx+nGvnKFXYiHjF+w6bg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/resolver-default": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.9.3.tgz",
-      "integrity": "sha512-8ESJk1COKvDzkmOnppNXoDamNMlYVIvrKc2RuFPmp8nKVj47R6NwMgvwxEaatyPzvkmyTpq5RvG9I3HFc+r4Cw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.10.0.tgz",
+      "integrity": "sha512-KWtKrmjf/CAyZkk+SSwHhMMwN6cjJJRtUSLCvwbrlevd0onRl3erUdVYrJrNB5X+N8ylCO6Vb0wCyMegOo/OwQ==",
       "dev": true,
       "requires": {
-        "@parcel/node-resolver-core": "3.0.3",
-        "@parcel/plugin": "2.9.3"
+        "@parcel/node-resolver-core": "3.1.0",
+        "@parcel/plugin": "2.10.0"
       }
     },
     "@parcel/runtime-browser-hmr": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.9.3.tgz",
-      "integrity": "sha512-EgiDIDrVAWpz7bOzWXqVinQkaFjLwT34wsonpXAbuI7f7r00d52vNAQC9AMu+pTijA3gyKoJ+Q4NWPMZf7ACDA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.10.0.tgz",
+      "integrity": "sha512-x22HHUAFuhycE/NGowkEaR7zeZsp8PcViHkmuNkSvLboe8PJvq4BFpnd+RUj+o8EjN31p+8K2pFqS1hYAmtdwg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3"
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0"
       }
     },
     "@parcel/runtime-js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.9.3.tgz",
-      "integrity": "sha512-EvIy+qXcKnB5qxHhe96zmJpSAViNVXHfQI5RSdZ2a7CPwORwhTI+zPNT9sb7xb/WwFw/WuTTgzT40b41DceU6Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.10.0.tgz",
+      "integrity": "sha512-AyDY+tQ9jiip6YsDGbaw7Azj60qG4fWNniUMIRMsywKQZOySLpfMNGHUcwDkV8j1NTve87Cwr2EzMOMnQHaUsQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/runtime-react-refresh": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.9.3.tgz",
-      "integrity": "sha512-XBgryZQIyCmi6JwEfMUCmINB3l1TpTp9a2iFxmYNpzHlqj4Ve0saKaqWOVRLvC945ZovWIBzcSW2IYqWKGtbAA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.10.0.tgz",
+      "integrity": "sha512-hmiK9i6iitdjfcCaI0888+pecQHA0dzf6wMKnwtJsYQxCv2TrwXPsSOMHjkKr1K3ALXi8vlauG4K0Rm7c+vfdw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/runtime-service-worker": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.9.3.tgz",
-      "integrity": "sha512-qLJLqv1mMdWL7gyh8aKBFFAuEiJkhUUgLKpdn6eSfH/R7kTtb76WnOwqUrhvEI9bZFUM/8Pa1bzJnPpqSOM+Sw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.10.0.tgz",
+      "integrity": "sha512-vi84PwAsyPI1P/5FTt1uNKjH1NGizQRdS4CmjBMz+VBT6GVuXMgZ9iQy3OYC8MsiyHlyG7mScftI74RWqw1DDg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1"
       }
+    },
+    "@parcel/rust": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.10.0.tgz",
+      "integrity": "sha512-9J7riqPI8mVlFSDphK9kVUH8nFQgeMbO/95Ycf4vaEOVE1ICQo1h18WHAy2DndmL1uSd/UTimirrP6yLt/I3KA==",
+      "dev": true
     },
     "@parcel/source-map": {
       "version": "2.1.1",
@@ -4181,15 +4391,15 @@
       }
     },
     "@parcel/transformer-babel": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.9.3.tgz",
-      "integrity": "sha512-pURtEsnsp3h6tOBDuzh9wRvVtw4PgIlqwAArIWdrG7iwqOUYv9D8ME4+ePWEu7MQWAp58hv9pTJtqWv4T+Sq8A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.10.0.tgz",
+      "integrity": "sha512-XwlzHt7WPfueFlwl/bXItopgZ6ILSPzl5OmPeytHrM2TanymeLjJ1y3vxwY1C1BhNlrTwPHcf9U8aiuVSpE8RQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.10.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -4197,29 +4407,29 @@
       }
     },
     "@parcel/transformer-css": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.9.3.tgz",
-      "integrity": "sha512-duWMdbEBBPjg3fQdXF16iWIdThetDZvCs2TpUD7xOlXH6kR0V5BJy8ONFT15u1RCqIV9hSNGaS3v3I9YRNY5zQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.10.0.tgz",
+      "integrity": "sha512-hITticpUE/qilpsTc7HQP04qhXwyUSKGZKgcFnvf8+BJO/LoclbVK1nzbR61eYl5Jhj1XB67p3tCt5fSvPhOsQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
+        "@parcel/utils": "2.10.0",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.16.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-html": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.9.3.tgz",
-      "integrity": "sha512-0NU4omcHzFXA1seqftAXA2KNZaMByoKaNdXnLgBgtCGDiYvOcL+6xGHgY6pw9LvOh5um10KI5TxSIMILoI7VtA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.10.0.tgz",
+      "integrity": "sha512-rc8YKjB+bE7yGHOf674CSzW8ii+m5caBo4akdRIUdhEHJS4FnSwxYIZlMcfV9pZM4Tj5PFMZyrlAHad6YrO8aA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -4229,28 +4439,29 @@
       }
     },
     "@parcel/transformer-image": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.9.3.tgz",
-      "integrity": "sha512-7CEe35RaPadQzLIuxzTtIxnItvOoy46hcbXtOdDt6lmVa4omuOygZYRIya2lsGIP4JHvAaALMb5nt99a1uTwJg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.10.0.tgz",
+      "integrity": "sha512-qbNyAJvzqdO/OnHhCOoPAZN5aBD/xphyXvDNI0Fb3UPEr5MQtAnzv2lS1I63s4rKpphBntWj7nEIAio6s7c5bw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
+        "@parcel/workers": "2.10.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.9.3.tgz",
-      "integrity": "sha512-Z2MVVg5FYcPOfxlUwxqb5l9yjTMEqE3KI3zq2MBRUme6AV07KxLmCDF23b6glzZlHWQUE8MXzYCTAkOPCcPz+Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.10.0.tgz",
+      "integrity": "sha512-39ZNnje8dlmME1ipjFyAFHyhHaGCwZZpXYN9SCTl/+AnjZLamnmVFkesgBbrRSBRQixRG1VwCvrWsjLLeLkTUg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.9.3",
-        "@parcel/workers": "2.9.3",
+        "@parcel/utils": "2.10.0",
+        "@parcel/workers": "2.10.0",
         "@swc/helpers": "^0.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1",
@@ -4259,25 +4470,25 @@
       }
     },
     "@parcel/transformer-json": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.9.3.tgz",
-      "integrity": "sha512-yNL27dbOLhkkrjaQjiQ7Im9VOxmkfuuSNSmS0rA3gEjVcm07SLKRzWkAaPnyx44Lb6bzyOTWwVrb9aMmxgADpA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.10.0.tgz",
+      "integrity": "sha512-4G6ZIt7IYu1l3BlsL55Hi3869X6KHE0CHybWf364h5ZUmzo3Xpc5i7cziQX+IhWDo1qn1jiziOPGY85LXlo8ug==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
+        "@parcel/plugin": "2.10.0",
         "json5": "^2.2.0"
       }
     },
     "@parcel/transformer-postcss": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.9.3.tgz",
-      "integrity": "sha512-HoDvPqKzhpmvMmHqQhDnt8F1vH61m6plpGiYaYnYv2Om4HHi5ZIq9bO+9QLBnTKfaZ7ndYSefTKOxTYElg7wyw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.10.0.tgz",
+      "integrity": "sha512-Xhz+MHr9Q31d3u3hsBOtmFGEQx7FsNbTumGpqIqaGkDDq4IIMKbEwyrpkmf7/02kyxcbwr6uaBqnMHm55j10sQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -4285,13 +4496,13 @@
       }
     },
     "@parcel/transformer-posthtml": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.9.3.tgz",
-      "integrity": "sha512-2fQGgrzRmaqbWf3y2/T6xhqrNjzqMMKksqJzvc8TMfK6f2kg3Ddjv158eaSW2JdkV39aY7tvAOn5f1uzo74BMA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.10.0.tgz",
+      "integrity": "sha512-kmz8Yip5hh2y3bfA76mC2QtI9VHdS7k5dV96/yjar0CkLHJnr33Jh7MTfuCN+01nVU20Tn3YMqEMQ/ErPVJwlg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -4300,34 +4511,34 @@
       }
     },
     "@parcel/transformer-raw": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.9.3.tgz",
-      "integrity": "sha512-oqdPzMC9QzWRbY9J6TZEqltknjno+dY24QWqf8ondmdF2+W+/2mRDu59hhCzQrqUHgTq4FewowRZmSfpzHxwaQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.10.0.tgz",
+      "integrity": "sha512-1tR58kqzTh4baLq/++bp84H2lhOoAz8cJeJykgsYImva7aRWcjlTppNKjBF6Ef8etIRMPZOozTdbS53VdQ9IbA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3"
+        "@parcel/plugin": "2.10.0"
       }
     },
     "@parcel/transformer-react-refresh-wrap": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.9.3.tgz",
-      "integrity": "sha512-cb9NyU6oJlDblFIlzqIE8AkvRQVGl2IwJNKwD4PdE7Y6sq2okGEPG4hOw3k/Y9JVjM4/2pUORqvjSRhWwd9oVQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.10.0.tgz",
+      "integrity": "sha512-4ab1tiwUA2XznTh/eb/IVKEA+Ynkbqc5sgNuobf1MLKF82FXTUT5szVshff/ODpwublvVBD3YbXlapxV5xyFvA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/transformer-svg": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.9.3.tgz",
-      "integrity": "sha512-ypmE+dzB09IMCdEAkOsSxq1dEIm2A3h67nAFz4qbfHbwNgXBUuy/jB3ZMwXN/cO0f7SBh/Ap8Jhq6vmGqB5tWw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.10.0.tgz",
+      "integrity": "sha512-qEZFk4gxyVNhm2V8R3YLo9qCyYNVBySWmZLjmwuhLLmAE+r0qGebc9oXyo7C6ML5d/4Tfj6NriCOeX+HMhPVxw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/plugin": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/plugin": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -4336,52 +4547,54 @@
       }
     },
     "@parcel/types": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.9.3.tgz",
-      "integrity": "sha512-NSNY8sYtRhvF1SqhnIGgGvJocyWt1K8Tnw5cVepm0g38ywtX6mwkBvMkmeehXkII4mSUn+frD9wGsydTunezvA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.10.0.tgz",
+      "integrity": "sha512-iDFVvgN+jK02GY++V+WY3WuNTM6CGDPToGfL31/Sgf6/1PzT7kL6uXJ6+859u8wkTIrtkWD2XyTNkKJJ8jPwgg==",
       "dev": true,
       "requires": {
-        "@parcel/cache": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/package-manager": "2.9.3",
+        "@parcel/cache": "2.10.0",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/fs": "2.10.0",
+        "@parcel/package-manager": "2.10.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/workers": "2.9.3",
+        "@parcel/workers": "2.10.0",
         "utility-types": "^3.10.0"
       }
     },
     "@parcel/utils": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.9.3.tgz",
-      "integrity": "sha512-cesanjtj/oLehW8Waq9JFPmAImhoiHX03ihc3JTWkrvJYSbD7wYKCDgPAM3JiRAqvh1LZ6P699uITrYWNoRLUg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.10.0.tgz",
+      "integrity": "sha512-8qx9caJTjli6UKpKlcPjdSBblkwTc+BnIsSK3/7fX7kbtHLmEkQH/RWZbbOJItHbnzlsmaDJTfS7j6rrcFw2Pw==",
       "dev": true,
       "requires": {
-        "@parcel/codeframe": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/hash": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/markdown-ansi": "2.9.3",
+        "@parcel/codeframe": "2.10.0",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/markdown-ansi": "2.10.0",
+        "@parcel/rust": "2.10.0",
         "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/watcher": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.2.0.tgz",
-      "integrity": "sha512-71S4TF+IMyAn24PK4KSkdKtqJDR3zRzb0HE3yXpacItqTM7XfF2f5q9NEGLEVl0dAaBAGfNwDCjH120y25F6Tg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.3.0.tgz",
+      "integrity": "sha512-pW7QaFiL11O0BphO+bq3MgqeX/INAk9jgBldVDYjlQPO4VddoZnF22TcF9onMhnLVHuNqBJeRf+Fj7eezi/+rQ==",
       "dev": true,
       "requires": {
-        "@parcel/watcher-android-arm64": "2.2.0",
-        "@parcel/watcher-darwin-arm64": "2.2.0",
-        "@parcel/watcher-darwin-x64": "2.2.0",
-        "@parcel/watcher-linux-arm-glibc": "2.2.0",
-        "@parcel/watcher-linux-arm64-glibc": "2.2.0",
-        "@parcel/watcher-linux-arm64-musl": "2.2.0",
-        "@parcel/watcher-linux-x64-glibc": "2.2.0",
-        "@parcel/watcher-linux-x64-musl": "2.2.0",
-        "@parcel/watcher-win32-arm64": "2.2.0",
-        "@parcel/watcher-win32-x64": "2.2.0",
+        "@parcel/watcher-android-arm64": "2.3.0",
+        "@parcel/watcher-darwin-arm64": "2.3.0",
+        "@parcel/watcher-darwin-x64": "2.3.0",
+        "@parcel/watcher-freebsd-x64": "2.3.0",
+        "@parcel/watcher-linux-arm-glibc": "2.3.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.3.0",
+        "@parcel/watcher-linux-arm64-musl": "2.3.0",
+        "@parcel/watcher-linux-x64-glibc": "2.3.0",
+        "@parcel/watcher-linux-x64-musl": "2.3.0",
+        "@parcel/watcher-win32-arm64": "2.3.0",
+        "@parcel/watcher-win32-ia32": "2.3.0",
+        "@parcel/watcher-win32-x64": "2.3.0",
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
         "micromatch": "^4.0.5",
@@ -4389,185 +4602,213 @@
       }
     },
     "@parcel/watcher-android-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.2.0.tgz",
-      "integrity": "sha512-nU2wh00CTQT9rr1TIKTjdQ9lAGYpmz6XuKw0nAwAN+S2A5YiD55BK1u+E5WMCT8YOIDe/n6gaj4o/Bi9294SSQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.3.0.tgz",
+      "integrity": "sha512-f4o9eA3dgk0XRT3XhB0UWpWpLnKgrh1IwNJKJ7UJek7eTYccQ8LR7XUWFKqw6aEq5KUNlCcGvSzKqSX/vtWVVA==",
       "dev": true,
       "optional": true
     },
     "@parcel/watcher-darwin-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.2.0.tgz",
-      "integrity": "sha512-cJl0UZDcodciy3TDMomoK/Huxpjlkkim3SyMgWzjovHGOZKNce9guLz2dzuFwfObBFCjfznbFMIvAZ5syXotYw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.3.0.tgz",
+      "integrity": "sha512-mKY+oijI4ahBMc/GygVGvEdOq0L4DxhYgwQqYAz/7yPzuGi79oXrZG52WdpGA1wLBPrYb0T8uBaGFo7I6rvSKw==",
       "dev": true,
       "optional": true
     },
     "@parcel/watcher-darwin-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.2.0.tgz",
-      "integrity": "sha512-QI77zxaGrCV1StKcoRYfsUfmUmvPMPfQrubkBBy5XujV2fwaLgZivQOTQMBgp5K2+E19u1ufpspKXAPqSzpbyg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.3.0.tgz",
+      "integrity": "sha512-20oBj8LcEOnLE3mgpy6zuOq8AplPu9NcSSSfyVKgfOhNAc4eF4ob3ldj0xWjGGbOF7Dcy1Tvm6ytvgdjlfUeow==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-freebsd-x64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.3.0.tgz",
+      "integrity": "sha512-7LftKlaHunueAEiojhCn+Ef2CTXWsLgTl4hq0pkhkTBFI3ssj2bJXmH2L67mKpiAD5dz66JYk4zS66qzdnIOgw==",
       "dev": true,
       "optional": true
     },
     "@parcel/watcher-linux-arm-glibc": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.2.0.tgz",
-      "integrity": "sha512-I2GPBcAXazPzabCmfsa3HRRW+MGlqxYd8g8RIueJU+a4o5nyNZDz0CR1cu0INT0QSQXEZV7w6UE8Hz9CF8u3Pg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.3.0.tgz",
+      "integrity": "sha512-1apPw5cD2xBv1XIHPUlq0cO6iAaEUQ3BcY0ysSyD9Kuyw4MoWm1DV+W9mneWI+1g6OeP6dhikiFE6BlU+AToTQ==",
       "dev": true,
       "optional": true
     },
     "@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.2.0.tgz",
-      "integrity": "sha512-St5mlfp+2lS9AmgixUqfwJa/DwVmTCJxC1HcOubUTz6YFOKIlkHCeUa1Bxi4E/tR/HSez8+heXHL8HQkJ4Bd8g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.3.0.tgz",
+      "integrity": "sha512-mQ0gBSQEiq1k/MMkgcSB0Ic47UORZBmWoAWlMrTW6nbAGoLZP+h7AtUM7H3oDu34TBFFvjy4JCGP43JlylkTQA==",
       "dev": true,
       "optional": true
     },
     "@parcel/watcher-linux-arm64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.2.0.tgz",
-      "integrity": "sha512-jS+qfhhoOBVWwMLP65MaG8xdInMK30pPW8wqTCg2AAuVJh5xepMbzkhHJ4zURqHiyY3EiIRuYu4ONJKCxt8iqA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.3.0.tgz",
+      "integrity": "sha512-LXZAExpepJew0Gp8ZkJ+xDZaTQjLHv48h0p0Vw2VMFQ8A+RKrAvpFuPVCVwKJCr5SE+zvaG+Etg56qXvTDIedw==",
       "dev": true,
       "optional": true
     },
     "@parcel/watcher-linux-x64-glibc": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.2.0.tgz",
-      "integrity": "sha512-xJvJ7R2wJdi47WZBFS691RDOWvP1j/IAs3EXaWVhDI8FFITbWrWaln7KoNcR0Y3T+ZwimFY/cfb0PNht1q895g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.3.0.tgz",
+      "integrity": "sha512-P7Wo91lKSeSgMTtG7CnBS6WrA5otr1K7shhSjKHNePVmfBHDoAOHYRXgUmhiNfbcGk0uMCHVcdbfxtuiZCHVow==",
       "dev": true,
       "optional": true
     },
     "@parcel/watcher-linux-x64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.2.0.tgz",
-      "integrity": "sha512-D+NMpgr23a+RI5mu8ZPKWy7AqjBOkURFDgP5iIXXEf/K3hm0jJ3ogzi0Ed2237B/CdYREimCgXyeiAlE/FtwyA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.3.0.tgz",
+      "integrity": "sha512-+kiRE1JIq8QdxzwoYY+wzBs9YbJ34guBweTK8nlzLKimn5EQ2b2FSC+tAOpq302BuIMjyuUGvBiUhEcLIGMQ5g==",
       "dev": true,
       "optional": true
     },
     "@parcel/watcher-win32-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.2.0.tgz",
-      "integrity": "sha512-z225cPn3aygJsyVUOWwfyW+fY0Tvk7N3XCOl66qUPFxpbuXeZuiuuJemmtm8vxyqa3Ur7peU/qJxrpC64aeI7Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.3.0.tgz",
+      "integrity": "sha512-35gXCnaz1AqIXpG42evcoP2+sNL62gZTMZne3IackM+6QlfMcJLy3DrjuL6Iks7Czpd3j4xRBzez3ADCj1l7Aw==",
+      "dev": true,
+      "optional": true
+    },
+    "@parcel/watcher-win32-ia32": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.3.0.tgz",
+      "integrity": "sha512-FJS/IBQHhRpZ6PiCjFt1UAcPr0YmCLHRbTc00IBTrelEjlmmgIVLeOx4MSXzx2HFEy5Jo5YdhGpxCuqCyDJ5ow==",
       "dev": true,
       "optional": true
     },
     "@parcel/watcher-win32-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.2.0.tgz",
-      "integrity": "sha512-JqGW0RJ61BkKx+yYzIURt9s53P7xMVbv0uxYPzAXLBINGaFmkIKSuUPyBVfy8TMbvp93lvF4SPBNDzVRJfvgOw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.3.0.tgz",
+      "integrity": "sha512-dLx+0XRdMnVI62kU3wbXvbIRhLck4aE28bIGKbRGS7BJNt54IIj9+c/Dkqb+7DJEbHUZAX1bwaoM8PqVlHJmCA==",
       "dev": true,
       "optional": true
     },
     "@parcel/workers": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.9.3.tgz",
-      "integrity": "sha512-zRrDuZJzTevrrwElYosFztgldhqW6G9q5zOeQXfVQFkkEJCNfg36ixeiofKRU8uu2x+j+T6216mhMNB6HiuY+w==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.10.0.tgz",
+      "integrity": "sha512-PILDag4aW7G9w2AvYvBsMHe/NRCoOt+L7HJzp6UIvy6ssbafH/8fzdGjSpA99GXzC5AXpAHVt8RXhGMXmMP6QA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/profiler": "2.9.3",
-        "@parcel/types": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/profiler": "2.10.0",
+        "@parcel/types": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@swc/core": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.67.tgz",
-      "integrity": "sha512-9DROjzfAEt0xt0CDkOYsWpkUPyne8fl5ggWGon049678BOM7p0R0dmaalZGAsKatG5vYP1IWSKWsKhJIubDCsQ==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.92.tgz",
+      "integrity": "sha512-vx0vUrf4YTEw59njOJ46Ha5i0cZTMYdRHQ7KXU29efN1MxcmJH2RajWLPlvQarOP1ab9iv9cApD7SMchDyx2vA==",
       "dev": true,
       "requires": {
-        "@swc/core-darwin-arm64": "1.3.67",
-        "@swc/core-darwin-x64": "1.3.67",
-        "@swc/core-linux-arm-gnueabihf": "1.3.67",
-        "@swc/core-linux-arm64-gnu": "1.3.67",
-        "@swc/core-linux-arm64-musl": "1.3.67",
-        "@swc/core-linux-x64-gnu": "1.3.67",
-        "@swc/core-linux-x64-musl": "1.3.67",
-        "@swc/core-win32-arm64-msvc": "1.3.67",
-        "@swc/core-win32-ia32-msvc": "1.3.67",
-        "@swc/core-win32-x64-msvc": "1.3.67"
+        "@swc/core-darwin-arm64": "1.3.92",
+        "@swc/core-darwin-x64": "1.3.92",
+        "@swc/core-linux-arm-gnueabihf": "1.3.92",
+        "@swc/core-linux-arm64-gnu": "1.3.92",
+        "@swc/core-linux-arm64-musl": "1.3.92",
+        "@swc/core-linux-x64-gnu": "1.3.92",
+        "@swc/core-linux-x64-musl": "1.3.92",
+        "@swc/core-win32-arm64-msvc": "1.3.92",
+        "@swc/core-win32-ia32-msvc": "1.3.92",
+        "@swc/core-win32-x64-msvc": "1.3.92",
+        "@swc/counter": "^0.1.1",
+        "@swc/types": "^0.1.5"
       }
     },
     "@swc/core-darwin-arm64": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.67.tgz",
-      "integrity": "sha512-zCT2mCkOBVNf5uJDcQ3A9KDoO1OEaGdfjsRTZTo7sejDd9AXLfJg+xgyCBBrK2jNS/uWcT21IvSv3LqKp4K8pA==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.92.tgz",
+      "integrity": "sha512-v7PqZUBtIF6Q5Cp48gqUiG8zQQnEICpnfNdoiY3xjQAglCGIQCjJIDjreZBoeZQZspB27lQN4eZ43CX18+2SnA==",
       "dev": true,
       "optional": true
     },
     "@swc/core-darwin-x64": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.67.tgz",
-      "integrity": "sha512-hXTVsfTatPEec5gFVyjGj3NccKZsYj/OXyHn6XA+l3Q76lZzGm2ISHdku//XNwXu8OmJ0HhS7LPsC4XXwxXQhg==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.92.tgz",
+      "integrity": "sha512-Q3XIgQfXyxxxms3bPN+xGgvwk0TtG9l89IomApu+yTKzaIIlf051mS+lGngjnh9L0aUiCp6ICyjDLtutWP54fw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.67.tgz",
-      "integrity": "sha512-l8AKL0RkDL5FRTeWMmjoz9zvAc37amxC+0rheaNwE+gZya7ObyNjnIYz5FwN+3y+z6JFU7LS2x/5f6iwruv6pg==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.92.tgz",
+      "integrity": "sha512-tnOCoCpNVXC+0FCfG84PBZJyLlz0Vfj9MQhyhCvlJz9hQmvpf8nTdKH7RHrOn8VfxtUBLdVi80dXgIFgbvl7qA==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-gnu": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.67.tgz",
-      "integrity": "sha512-S8zOB1AXEpb7kmtgMaFNeLAj01VOky4B0RNZ+uJWigdrDiFT67FeZzNHUNmNSOU0QM79G+Lie/xD/beqEw0vDg==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.92.tgz",
+      "integrity": "sha512-lFfGhX32w8h1j74Iyz0Wv7JByXIwX11OE9UxG+oT7lG0RyXkF4zKyxP8EoxfLrDXse4Oop434p95e3UNC3IfCw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-musl": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.67.tgz",
-      "integrity": "sha512-Fex8J8ASrt13pmOr2xWh41tEeKWwXYGk3sV8L/aGHiYtIJEUi2f+RtMx3jp7LIdOD8pQptor7i5WBlfR9jhp8A==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.92.tgz",
+      "integrity": "sha512-rOZtRcLj57MSAbiecMsqjzBcZDuaCZ8F6l6JDwGkQ7u1NYR57cqF0QDyU7RKS1Jq27Z/Vg21z5cwqoH5fLN+Sg==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.67.tgz",
-      "integrity": "sha512-9bz9/bMphrv5vDg0os/d8ve0QgFpDzJgZgHUaHiGwcmfnlgdOSAaYJLIvWdcGTjZuQeV4L0m+iru357D9TXEzA==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.92.tgz",
+      "integrity": "sha512-qptoMGnBL6v89x/Qpn+l1TH1Y0ed+v0qhNfAEVzZvCvzEMTFXphhlhYbDdpxbzRmCjH6GOGq7Y+xrWt9T1/ARg==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.67.tgz",
-      "integrity": "sha512-ED0H6oLvQmhgo9zs8usmEA/lcZPGTu7K9og9K871b7HhHX0h/R+Xg2pb5KD7S/GyUHpfuopxjVROm+h6X1jMUA==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.92.tgz",
+      "integrity": "sha512-g2KrJ43bZkCZHH4zsIV5ErojuV1OIpUHaEyW1gf7JWKaFBpWYVyubzFPvPkjcxHGLbMsEzO7w/NVfxtGMlFH/Q==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-arm64-msvc": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.67.tgz",
-      "integrity": "sha512-J1yFDLgPFeRtA8t5E159OXX+ww1gbkFg70yr4OP7EsOkOD1uMkuTf9yK/woHfsaVJlUYjJHzw7MkUIEgQBucqQ==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.92.tgz",
+      "integrity": "sha512-3MCRGPAYDoQ8Yyd3WsCMc8eFSyKXY5kQLyg/R5zEqA0uthomo0m0F5/fxAJMZGaSdYkU1DgF73ctOWOf+Z/EzQ==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-ia32-msvc": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.67.tgz",
-      "integrity": "sha512-bK11/KtasewqHxzkjKUBXRE9MSAidbZCxrgJUd49bItG2N/DHxkwMYu8Xkh5VDHdTYWv/2idYtf/VM9Yi+53qw==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.92.tgz",
+      "integrity": "sha512-zqTBKQhgfWm73SVGS8FKhFYDovyRl1f5dTX1IwSKynO0qHkRCqJwauFJv/yevkpJWsI2pFh03xsRs9HncTQKSA==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-x64-msvc": {
-      "version": "1.3.67",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.67.tgz",
-      "integrity": "sha512-GxzUU3+NA3cPcYxCxtfSQIS2ySD7Z8IZmKTVaWA9GOUQbKLyCE8H5js31u39+0op/1gNgxOgYFDoj2lUyvLCqw==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.92.tgz",
+      "integrity": "sha512-41bE66ddr9o/Fi1FBh0sHdaKdENPTuDpv1IFHxSg0dJyM/jX8LbkjnpdInYXHBxhcLVAPraVRrNsC4SaoPw2Pg==",
       "dev": true,
       "optional": true
     },
+    "@swc/counter": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.2.tgz",
+      "integrity": "sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==",
+      "dev": true
+    },
     "@swc/helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.3.tgz",
+      "integrity": "sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==",
       "dev": true,
       "requires": {
         "tslib": "^2.4.0"
       }
+    },
+    "@swc/types": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
+      "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
+      "dev": true
     },
     "@trysound/sax": {
       "version": "0.2.0",
@@ -4621,15 +4862,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001503",
-        "electron-to-chromium": "^1.4.431",
-        "node-releases": "^2.0.12",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       }
     },
     "callsites": {
@@ -4639,9 +4880,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001511",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001511.tgz",
-      "integrity": "sha512-NaWPJawcoedlghN4P7bDNeADD7K+rZaY6V8ZcME7PkEZo/nfOg+lnrUgRWiKbNxcQ4/toFKSxnS4WdbyPZnKkw==",
+      "version": "1.0.30001547",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001547.tgz",
+      "integrity": "sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA==",
       "dev": true
     },
     "chalk": {
@@ -4688,14 +4929,14 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "requires": {
-        "import-fresh": "^3.2.1",
+        "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.0.0",
+        "parse-json": "^5.2.0",
         "path-type": "^4.0.0"
       }
     },
@@ -4876,9 +5117,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.447",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.447.tgz",
-      "integrity": "sha512-sxX0LXh+uL41hSJsujAN86PjhrV/6c79XmpY0TvjZStV6VxIgarf8SRkUoUTuYmFcZQTemsoqo8qXOGw5npWfw==",
+      "version": "1.4.552",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.552.tgz",
+      "integrity": "sha512-qMPzA5TEuOAbLFmbpNvO4qkBRe2B5dAxl6H4KxqRNy9cvBeHT2EyzecX0bumBfRhHN8cQJrx6NPd0AAoCCPKQw==",
       "dev": true
     },
     "entities": {
@@ -4924,9 +5165,9 @@
       "dev": true
     },
     "globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.23.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -5032,75 +5273,83 @@
       "dev": true
     },
     "lightningcss": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.21.2.tgz",
-      "integrity": "sha512-6GoGcH4CHGLN6hq5lcmtkKxolXw8nsmgoaYsy6AilwH0vS0GUpKlgFegaf7LmDZqxawjV6LmymQFBZYe+sS45w==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.22.0.tgz",
+      "integrity": "sha512-+z0qvwRVzs4XGRXelnWRNwqsXUx8k3bSkbP8vD42kYKSk3z9OM2P3e/gagT7ei/gwh8DTS80LZOFZV6lm8Z8Fg==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
-        "lightningcss-darwin-arm64": "1.21.2",
-        "lightningcss-darwin-x64": "1.21.2",
-        "lightningcss-linux-arm-gnueabihf": "1.21.2",
-        "lightningcss-linux-arm64-gnu": "1.21.2",
-        "lightningcss-linux-arm64-musl": "1.21.2",
-        "lightningcss-linux-x64-gnu": "1.21.2",
-        "lightningcss-linux-x64-musl": "1.21.2",
-        "lightningcss-win32-x64-msvc": "1.21.2"
+        "lightningcss-darwin-arm64": "1.22.0",
+        "lightningcss-darwin-x64": "1.22.0",
+        "lightningcss-freebsd-x64": "1.22.0",
+        "lightningcss-linux-arm-gnueabihf": "1.22.0",
+        "lightningcss-linux-arm64-gnu": "1.22.0",
+        "lightningcss-linux-arm64-musl": "1.22.0",
+        "lightningcss-linux-x64-gnu": "1.22.0",
+        "lightningcss-linux-x64-musl": "1.22.0",
+        "lightningcss-win32-x64-msvc": "1.22.0"
       }
     },
     "lightningcss-darwin-arm64": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.21.2.tgz",
-      "integrity": "sha512-uh2+MUWWc6rQpMfD3YoIRRxxRaUdhJSI3zeq7EXWQI4pDFcgV8LxGq6yfyMB0cJT1Hh55elQHM3Y139YJrhHFQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.22.0.tgz",
+      "integrity": "sha512-aH2be3nNny+It5YEVm8tBSSdRlBVWQV8m2oJ7dESiYRzyY/E/bQUe2xlw5caaMuhlM9aoTMtOH25yzMhir0qPg==",
       "dev": true,
       "optional": true
     },
     "lightningcss-darwin-x64": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.21.2.tgz",
-      "integrity": "sha512-Qv+Tra9p+Lqw4o3XMrDOJBWz5HhNueFHPG+AZMatyQKyWIVKTxDtW9/J7J7J8I2PE26UeLhlQE26ych5PGAp4Q==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.22.0.tgz",
+      "integrity": "sha512-9KHRFA0Y6mNxRHeoQMp0YaI0R0O2kOgUlYPRjuasU4d+pI8NRhVn9bt0yX9VPs5ibWX1RbDViSPtGJvYYrfVAQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-freebsd-x64": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.22.0.tgz",
+      "integrity": "sha512-xaYL3xperGwD85rQioDb52ozF3NAJb+9wrge3jD9lxGffplu0Mn35rXMptB8Uc2N9Mw1i3Bvl7+z1evlqVl7ww==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm-gnueabihf": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.21.2.tgz",
-      "integrity": "sha512-83KqiPvvOuAocrUyuV+V3peLe5cfBZRHV312vSJq/OGluHzeg2meb36q73q1gIcz/qX9RdAcx6GlhZ/vwbGpnQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.22.0.tgz",
+      "integrity": "sha512-epQGvXIjOuxrZpMpMnRjK54ZqzhiHhCPLtHvw2fb6NeK2kK9YtF0wqmeTBiQ1AkbWfnnXGTstYaFNiadNK+StQ==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-gnu": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.21.2.tgz",
-      "integrity": "sha512-YAFPWM8Wi2UXIf382aDGxx0/zxOROZ7ADTBi8coXmI5FjDqUjxypc4U9+o962oi3k/N3K6IaL2f/E172+Xj0vA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.22.0.tgz",
+      "integrity": "sha512-AArGtKSY4DGTA8xP8SDyNyKtpsUl1Rzq6FW4JomeyUQ4nBrR71uPChksTpj3gmWuGhZeRKLeCUI1DBid/zhChg==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-musl": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.21.2.tgz",
-      "integrity": "sha512-dTIaIbOgo/mYzkEi2ESI9+ciZz7un8G0AxiM8E8lrkelm3lgTnSO/4fWaEfx+u9LsVM7dgAN5cfiDBQCr2koYA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.22.0.tgz",
+      "integrity": "sha512-RRraNgP8hnBPhInTTUdlFm+z16C/ghbxBG51Sw00hd7HUyKmEUKRozyc5od+/N6pOrX/bIh5vIbtMXIxsos0lg==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-gnu": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.21.2.tgz",
-      "integrity": "sha512-xFieDlPN2cfoVKVBg5XLyxvIAJPw2J3njlOFUQOJEDbLbp+qI8hgxqz34dlI/zZMq4Dmzroc7LPB/MengYjYHQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.22.0.tgz",
+      "integrity": "sha512-grdrhYGRi2KrR+bsXJVI0myRADqyA7ekprGxiuK5QRNkv7kj3Yq1fERDNyzZvjisHwKUi29sYMClscbtl+/Zpw==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-musl": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.21.2.tgz",
-      "integrity": "sha512-1w+oiZY3H1V/5FxpvtEUXHBZFuAPzUFoFolpDKNDphr9h9xPo3xc2eg3zuz96ia+tb2QmBB5S3QZrQ/dGGc8GA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.22.0.tgz",
+      "integrity": "sha512-t5f90X+iQUtIyR56oXIHMBUyQFX/zwmPt72E6Dane3P8KNGlkijTg2I75XVQS860gNoEFzV7Mm5ArRRA7u5CAQ==",
       "dev": true,
       "optional": true
     },
     "lightningcss-win32-x64-msvc": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.21.2.tgz",
-      "integrity": "sha512-NzuZx5gH7H6Me7h88Boil0vhIqs5+kQ8K2B6ZYQAllj8yk0zCs4cqOLUxXmm6fiykRxCzdRPcEP8ZYvbBCcGgw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.22.0.tgz",
+      "integrity": "sha512-64HTDtOOZE9PUCZJiZZQpyqXBbdby1lnztBccnqh+NtbKxjnGzP92R2ngcgeuqMPecMNqNWxgoWgTGpC+yN5Sw==",
       "dev": true,
       "optional": true
     },
@@ -5111,37 +5360,28 @@
       "dev": true
     },
     "lmdb": {
-      "version": "2.7.11",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.7.11.tgz",
-      "integrity": "sha512-x9bD4hVp7PFLUoELL8RglbNXhAMt5CYhkmss+CEau9KlNoilsTzNi9QDsPZb3KMpOGZXG6jmXhW3bBxE2XVztw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.8.5.tgz",
+      "integrity": "sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==",
       "dev": true,
       "requires": {
-        "@lmdb/lmdb-darwin-arm64": "2.7.11",
-        "@lmdb/lmdb-darwin-x64": "2.7.11",
-        "@lmdb/lmdb-linux-arm": "2.7.11",
-        "@lmdb/lmdb-linux-arm64": "2.7.11",
-        "@lmdb/lmdb-linux-x64": "2.7.11",
-        "@lmdb/lmdb-win32-x64": "2.7.11",
-        "msgpackr": "1.8.5",
-        "node-addon-api": "^4.3.0",
-        "node-gyp-build-optional-packages": "5.0.6",
-        "ordered-binary": "^1.4.0",
+        "@lmdb/lmdb-darwin-arm64": "2.8.5",
+        "@lmdb/lmdb-darwin-x64": "2.8.5",
+        "@lmdb/lmdb-linux-arm": "2.8.5",
+        "@lmdb/lmdb-linux-arm64": "2.8.5",
+        "@lmdb/lmdb-linux-x64": "2.8.5",
+        "@lmdb/lmdb-win32-x64": "2.8.5",
+        "msgpackr": "^1.9.5",
+        "node-addon-api": "^6.1.0",
+        "node-gyp-build-optional-packages": "5.1.1",
+        "ordered-binary": "^1.4.1",
         "weak-lru-cache": "^1.2.2"
       },
       "dependencies": {
-        "msgpackr": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.5.tgz",
-          "integrity": "sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==",
-          "dev": true,
-          "requires": {
-            "msgpackr-extract": "^3.0.1"
-          }
-        },
         "node-addon-api": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+          "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
           "dev": true
         }
       }
@@ -5174,9 +5414,9 @@
       }
     },
     "msgpackr": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.5.tgz",
-      "integrity": "sha512-/IJ3cFSN6Ci3eG2wLhbFEL6GT63yEaoN/R5My2QkV6zro+OJaVRLPlwvxY7EtHYSmDlQpk8stvOQTL2qJFkDRg==",
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.9.tgz",
+      "integrity": "sha512-sbn6mioS2w0lq1O6PpGtsv6Gy8roWM+o3o4Sqjd6DudrL/nOugY+KyJUimoWzHnf9OkO0T6broHFnYE/R05t9A==",
       "dev": true,
       "requires": {
         "msgpackr-extract": "^3.0.2"
@@ -5214,15 +5454,26 @@
       "dev": true
     },
     "node-gyp-build-optional-packages": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.6.tgz",
-      "integrity": "sha512-2ZJErHG4du9G3/8IWl/l9Bp5BBFy63rno5GVmjQijvTuUZKsl6g8RB4KH/x3NLcV5ZBb4GsXmAuTYr6dRml3Gw==",
-      "dev": true
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^2.0.1"
+      },
+      "dependencies": {
+        "detect-libc": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+          "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+          "dev": true
+        }
+      }
     },
     "node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "nth-check": {
@@ -5241,28 +5492,28 @@
       "dev": true
     },
     "ordered-binary": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.4.0.tgz",
-      "integrity": "sha512-EHQ/jk4/a9hLupIKxTfUsQRej1Yd/0QLQs3vGvIqg5ZtCYSzNhkzHoZc7Zf4e4kUlDaC3Uw8Q/1opOLNN2OKRQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.4.1.tgz",
+      "integrity": "sha512-9LtiGlPy982CsgxZvJGNNp2/NnrgEr6EAyN3iIEP3/8vd3YLgAZQHbQ75ZrkfBRGrNg37Dk3U6tuVb+B4Xfslg==",
       "dev": true
     },
     "parcel": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.9.3.tgz",
-      "integrity": "sha512-2GTVocFkwblV/TIg9AmT7TI2fO4xdWkyN8aFUEVtiVNWt96GTR3FgQyHFValfCbcj1k9Xf962Ws2hYXYUr9k1Q==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.10.0.tgz",
+      "integrity": "sha512-YJmWEsiv1ClpPcJiWkr3gFj40sRvfeK89GGGwJjpzQMQsBmN6h6OHrSkByx0jrsPIvdsOIccU702upYpRAypuw==",
       "dev": true,
       "requires": {
-        "@parcel/config-default": "2.9.3",
-        "@parcel/core": "2.9.3",
-        "@parcel/diagnostic": "2.9.3",
-        "@parcel/events": "2.9.3",
-        "@parcel/fs": "2.9.3",
-        "@parcel/logger": "2.9.3",
-        "@parcel/package-manager": "2.9.3",
-        "@parcel/reporter-cli": "2.9.3",
-        "@parcel/reporter-dev-server": "2.9.3",
-        "@parcel/reporter-tracer": "2.9.3",
-        "@parcel/utils": "2.9.3",
+        "@parcel/config-default": "2.10.0",
+        "@parcel/core": "2.10.0",
+        "@parcel/diagnostic": "2.10.0",
+        "@parcel/events": "2.10.0",
+        "@parcel/fs": "2.10.0",
+        "@parcel/logger": "2.10.0",
+        "@parcel/package-manager": "2.10.0",
+        "@parcel/reporter-cli": "2.10.0",
+        "@parcel/reporter-dev-server": "2.10.0",
+        "@parcel/reporter-tracer": "2.10.0",
+        "@parcel/utils": "2.10.0",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0"
@@ -5383,9 +5634,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -5464,9 +5715,9 @@
       }
     },
     "tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "type-fest": {
@@ -5476,15 +5727,15 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",
@@ -5501,12 +5752,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
-      "dev": true
-    },
-    "xxhash-wasm": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
-      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==",
       "dev": true
     },
     "yallist": {

--- a/projects/parcel-ts/package.json
+++ b/projects/parcel-ts/package.json
@@ -10,7 +10,7 @@
     "@maxgraph/core": "0.3.0"
   },
   "devDependencies": {
-    "parcel": "~2.9.3",
-    "typescript": "~5.1.6"
+    "parcel": "~2.10.0",
+    "typescript": "~5.2.2"
   }
 }

--- a/projects/rollup-ts/package-lock.json
+++ b/projects/rollup-ts/package-lock.json
@@ -11,15 +11,15 @@
         "@maxgraph/core": "0.3.0"
       },
       "devDependencies": {
-        "@rollup/plugin-node-resolve": "~15.1.0",
-        "@rollup/plugin-terser": "~0.4.3",
-        "@rollup/plugin-typescript": "~11.1.2",
+        "@rollup/plugin-node-resolve": "~15.2.3",
+        "@rollup/plugin-terser": "~0.4.4",
+        "@rollup/plugin-typescript": "~11.1.5",
         "copyfiles": "~2.4.1",
         "npm-run-all": "~4.1.5",
-        "rollup": "~3.26.0",
-        "serve": "~14.2.0",
-        "tslib": "~2.6.0",
-        "typescript": "~5.1.6"
+        "rollup": "~4.0.2",
+        "serve": "~14.2.1",
+        "tslib": "~2.6.2",
+        "typescript": "~5.2.2"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -92,9 +92,9 @@
       "integrity": "sha512-KRoB7eSd1Md9NFWjkUyUODPnE1LBLGLQ0KGO0RCsOD5Bf1vkC01+I873yvDqYWmfYk0vk2wWlp41m0pEsg9HzA=="
     },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.1.0.tgz",
-      "integrity": "sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==",
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
@@ -108,7 +108,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^2.78.0||^3.0.0"
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -117,9 +117,9 @@
       }
     },
     "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.3.tgz",
-      "integrity": "sha512-EF0oejTMtkyhrkwCdg0HJ0IpkcaVg1MMSf2olHb2Jp+1mnLM04OhjpJWGma4HobiDTF0WCyViWuvadyE9ch2XA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
       "dev": true,
       "dependencies": {
         "serialize-javascript": "^6.0.1",
@@ -130,7 +130,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^2.x || ^3.x"
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/@rollup/plugin-typescript": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.2.tgz",
-      "integrity": "sha512-0ghSOCMcA7fl1JM+0gYRf+Q/HWyg+zg7/gDSc+fRLmlJWcW5K1I+CLRzaRhXf4Y3DRyPnnDo4M2ktw+a6JcDEg==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.5.tgz",
+      "integrity": "sha512-rnMHrGBB0IUEv69Q8/JGRD/n4/n6b3nfpufUu26axhUcboUzv/twfZU8fIBbTOphRAe0v8EyxzeDpKXqGHfyDA==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
@@ -160,7 +160,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^2.14.0||^3.0.0",
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
         "tslib": "*",
         "typescript": ">=3.7.0"
       },
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
       "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -187,7 +187,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -195,10 +195,166 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.0.2.tgz",
+      "integrity": "sha512-xDvk1pT4vaPU2BOLy0MqHMdYZyntqpaBf8RhBiezlqG9OjY8F50TyctHo8znigYKd+QCFhCmlmXHOL/LoaOl3w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.0.2.tgz",
+      "integrity": "sha512-lqCglytY3E6raze27DD9VQJWohbwCxzqs9aSHcj5X/8hJpzZfNdbsr4Ja9Hqp6iPyF53+5PtPx0pKRlkSvlHZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.0.2.tgz",
+      "integrity": "sha512-nkBKItS6E6CCzvRwgiKad+j+1ibmL7SIInj7oqMWmdkCjiSX6VeVZw2mLlRKIUL+JjsBgpATTfo7BiAXc1v0jA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.0.2.tgz",
+      "integrity": "sha512-vX2C8xvWPIbpEgQht95+dY6BReKAvtDgPDGi0XN0kWJKkm4WdNmq5dnwscv/zxvi+n6jUTBhs6GtpkkWT4q8Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.0.2.tgz",
+      "integrity": "sha512-DVFIfcHOjgmeHOAqji4xNz2wczt1Bmzy9MwBZKBa83SjBVO/i38VHDR+9ixo8QpBOiEagmNw12DucG+v55tCrg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.0.2.tgz",
+      "integrity": "sha512-GCK/a9ItUxPI0V5hQEJjH4JtOJO90GF2Hja7TO+EZ8rmkGvEi8/ZDMhXmcuDpQT7/PWrTT9RvnG8snMd5SrhBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.0.2.tgz",
+      "integrity": "sha512-cLuBp7rOjIB1R2j/VazjCmHC7liWUur2e9mFflLJBAWCkrZ+X0+QwHLvOQakIwDymungzAKv6W9kHZnTp/Mqrg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.0.2.tgz",
+      "integrity": "sha512-Zqw4iVnJr2naoyQus0yLy7sLtisCQcpdMKUCeXPBjkJtpiflRime/TMojbnl8O3oxUAj92mxr+t7im/RbgA20w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.0.2.tgz",
+      "integrity": "sha512-jJRU9TyUD/iMqjf8aLAp7XiN3pIj5v6Qcu+cdzBfVTKDD0Fvua4oUoK8eVJ9ZuKBEQKt3WdlcwJXFkpmMLk6kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.0.2.tgz",
+      "integrity": "sha512-ZkS2NixCxHKC4zbOnw64ztEGGDVIYP6nKkGBfOAxEPW71Sji9v8z3yaHNuae/JHPwXA+14oDefnOuVfxl59SmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.0.2.tgz",
+      "integrity": "sha512-3SKjj+tvnZ0oZq2BKB+fI+DqYI83VrRzk7eed8tJkxeZ4zxJZcLSE8YDQLYGq1tZAnAX+H076RHHB4gTZXsQzw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.0.2.tgz",
+      "integrity": "sha512-MBdJIOxRauKkry7t2q+rTHa3aWjVez2eioWg+etRVS3dE4tChhmt5oqZYr48R6bPmcwEhxQr96gVRfeQrLbqng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
+      "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -1985,18 +2141,30 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.0.tgz",
-      "integrity": "sha512-YzJH0eunH2hr3knvF3i6IkLO/jTjAEwU4HoMUbQl4//Tnl3ou0e7P5SjxdDr8HQJdeUJShlbEHXrrnEHy1l7Yg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.0.2.tgz",
+      "integrity": "sha512-MCScu4usMPCeVFaiLcgMDaBQeYi1z6vpWxz0r0hq0Hv77Y2YuOTZldkuNJ54BdYBH3e+nkrk6j0Rre/NLDBYzg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=14.18.0",
+        "node": ">=18.0.0",
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.0.2",
+        "@rollup/rollup-android-arm64": "4.0.2",
+        "@rollup/rollup-darwin-arm64": "4.0.2",
+        "@rollup/rollup-darwin-x64": "4.0.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.0.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.0.2",
+        "@rollup/rollup-linux-arm64-musl": "4.0.2",
+        "@rollup/rollup-linux-x64-gnu": "4.0.2",
+        "@rollup/rollup-linux-x64-musl": "4.0.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.0.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.0.2",
+        "@rollup/rollup-win32-x64-msvc": "4.0.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -2028,9 +2196,9 @@
       }
     },
     "node_modules/serve": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.0.tgz",
-      "integrity": "sha512-+HOw/XK1bW8tw5iBilBz/mJLWRzM8XM6MPxL4J/dKzdxq1vfdEWSwhaR7/yS8EJp5wzvP92p1qirysJvnEtjXg==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.1.tgz",
+      "integrity": "sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==",
       "dev": true,
       "dependencies": {
         "@zeit/schemas": "2.29.0",
@@ -2390,9 +2558,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "node_modules/type-fest": {
@@ -2408,9 +2576,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2722,9 +2890,9 @@
       "integrity": "sha512-KRoB7eSd1Md9NFWjkUyUODPnE1LBLGLQ0KGO0RCsOD5Bf1vkC01+I873yvDqYWmfYk0vk2wWlp41m0pEsg9HzA=="
     },
     "@rollup/plugin-node-resolve": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.1.0.tgz",
-      "integrity": "sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==",
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^5.0.1",
@@ -2736,9 +2904,9 @@
       }
     },
     "@rollup/plugin-terser": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.3.tgz",
-      "integrity": "sha512-EF0oejTMtkyhrkwCdg0HJ0IpkcaVg1MMSf2olHb2Jp+1mnLM04OhjpJWGma4HobiDTF0WCyViWuvadyE9ch2XA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
       "dev": true,
       "requires": {
         "serialize-javascript": "^6.0.1",
@@ -2758,9 +2926,9 @@
       }
     },
     "@rollup/plugin-typescript": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.2.tgz",
-      "integrity": "sha512-0ghSOCMcA7fl1JM+0gYRf+Q/HWyg+zg7/gDSc+fRLmlJWcW5K1I+CLRzaRhXf4Y3DRyPnnDo4M2ktw+a6JcDEg==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.5.tgz",
+      "integrity": "sha512-rnMHrGBB0IUEv69Q8/JGRD/n4/n6b3nfpufUu26axhUcboUzv/twfZU8fIBbTOphRAe0v8EyxzeDpKXqGHfyDA==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^5.0.1",
@@ -2768,9 +2936,9 @@
       }
     },
     "@rollup/pluginutils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
       "dev": true,
       "requires": {
         "@types/estree": "^1.0.0",
@@ -2778,10 +2946,94 @@
         "picomatch": "^2.3.1"
       }
     },
+    "@rollup/rollup-android-arm-eabi": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.0.2.tgz",
+      "integrity": "sha512-xDvk1pT4vaPU2BOLy0MqHMdYZyntqpaBf8RhBiezlqG9OjY8F50TyctHo8znigYKd+QCFhCmlmXHOL/LoaOl3w==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-android-arm64": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.0.2.tgz",
+      "integrity": "sha512-lqCglytY3E6raze27DD9VQJWohbwCxzqs9aSHcj5X/8hJpzZfNdbsr4Ja9Hqp6iPyF53+5PtPx0pKRlkSvlHZg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-arm64": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.0.2.tgz",
+      "integrity": "sha512-nkBKItS6E6CCzvRwgiKad+j+1ibmL7SIInj7oqMWmdkCjiSX6VeVZw2mLlRKIUL+JjsBgpATTfo7BiAXc1v0jA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-x64": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.0.2.tgz",
+      "integrity": "sha512-vX2C8xvWPIbpEgQht95+dY6BReKAvtDgPDGi0XN0kWJKkm4WdNmq5dnwscv/zxvi+n6jUTBhs6GtpkkWT4q8Gg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.0.2.tgz",
+      "integrity": "sha512-DVFIfcHOjgmeHOAqji4xNz2wczt1Bmzy9MwBZKBa83SjBVO/i38VHDR+9ixo8QpBOiEagmNw12DucG+v55tCrg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.0.2.tgz",
+      "integrity": "sha512-GCK/a9ItUxPI0V5hQEJjH4JtOJO90GF2Hja7TO+EZ8rmkGvEi8/ZDMhXmcuDpQT7/PWrTT9RvnG8snMd5SrhBQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-musl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.0.2.tgz",
+      "integrity": "sha512-cLuBp7rOjIB1R2j/VazjCmHC7liWUur2e9mFflLJBAWCkrZ+X0+QwHLvOQakIwDymungzAKv6W9kHZnTp/Mqrg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-gnu": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.0.2.tgz",
+      "integrity": "sha512-Zqw4iVnJr2naoyQus0yLy7sLtisCQcpdMKUCeXPBjkJtpiflRime/TMojbnl8O3oxUAj92mxr+t7im/RbgA20w==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-musl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.0.2.tgz",
+      "integrity": "sha512-jJRU9TyUD/iMqjf8aLAp7XiN3pIj5v6Qcu+cdzBfVTKDD0Fvua4oUoK8eVJ9ZuKBEQKt3WdlcwJXFkpmMLk6kg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.0.2.tgz",
+      "integrity": "sha512-ZkS2NixCxHKC4zbOnw64ztEGGDVIYP6nKkGBfOAxEPW71Sji9v8z3yaHNuae/JHPwXA+14oDefnOuVfxl59SmQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.0.2.tgz",
+      "integrity": "sha512-3SKjj+tvnZ0oZq2BKB+fI+DqYI83VrRzk7eed8tJkxeZ4zxJZcLSE8YDQLYGq1tZAnAX+H076RHHB4gTZXsQzw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-x64-msvc": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.0.2.tgz",
+      "integrity": "sha512-MBdJIOxRauKkry7t2q+rTHa3aWjVez2eioWg+etRVS3dE4tChhmt5oqZYr48R6bPmcwEhxQr96gVRfeQrLbqng==",
+      "dev": true,
+      "optional": true
+    },
     "@types/estree": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
+      "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==",
       "dev": true
     },
     "@types/resolve": {
@@ -4025,11 +4277,23 @@
       }
     },
     "rollup": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.0.tgz",
-      "integrity": "sha512-YzJH0eunH2hr3knvF3i6IkLO/jTjAEwU4HoMUbQl4//Tnl3ou0e7P5SjxdDr8HQJdeUJShlbEHXrrnEHy1l7Yg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.0.2.tgz",
+      "integrity": "sha512-MCScu4usMPCeVFaiLcgMDaBQeYi1z6vpWxz0r0hq0Hv77Y2YuOTZldkuNJ54BdYBH3e+nkrk6j0Rre/NLDBYzg==",
       "dev": true,
       "requires": {
+        "@rollup/rollup-android-arm-eabi": "4.0.2",
+        "@rollup/rollup-android-arm64": "4.0.2",
+        "@rollup/rollup-darwin-arm64": "4.0.2",
+        "@rollup/rollup-darwin-x64": "4.0.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.0.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.0.2",
+        "@rollup/rollup-linux-arm64-musl": "4.0.2",
+        "@rollup/rollup-linux-x64-gnu": "4.0.2",
+        "@rollup/rollup-linux-x64-musl": "4.0.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.0.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.0.2",
+        "@rollup/rollup-win32-x64-msvc": "4.0.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -4042,9 +4306,9 @@
       "dev": true
     },
     "serve": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.0.tgz",
-      "integrity": "sha512-+HOw/XK1bW8tw5iBilBz/mJLWRzM8XM6MPxL4J/dKzdxq1vfdEWSwhaR7/yS8EJp5wzvP92p1qirysJvnEtjXg==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.1.tgz",
+      "integrity": "sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==",
       "dev": true,
       "requires": {
         "@zeit/schemas": "2.29.0",
@@ -4318,9 +4582,9 @@
       }
     },
     "tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "type-fest": {
@@ -4330,9 +4594,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "unbox-primitive": {

--- a/projects/rollup-ts/package.json
+++ b/projects/rollup-ts/package.json
@@ -14,14 +14,14 @@
     "@maxgraph/core": "0.3.0"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "~15.1.0",
-    "@rollup/plugin-terser": "~0.4.3",
-    "@rollup/plugin-typescript": "~11.1.2",
+    "@rollup/plugin-node-resolve": "~15.2.3",
+    "@rollup/plugin-terser": "~0.4.4",
+    "@rollup/plugin-typescript": "~11.1.5",
     "copyfiles": "~2.4.1",
     "npm-run-all": "~4.1.5",
-    "rollup": "~3.26.0",
-    "serve": "~14.2.0",
-    "tslib": "~2.6.0",
-    "typescript": "~5.1.6"
+    "rollup": "~4.0.2",
+    "serve": "~14.2.1",
+    "tslib": "~2.6.2",
+    "typescript": "~5.2.2"
   }
 }

--- a/projects/vitejs-ts/package-lock.json
+++ b/projects/vitejs-ts/package-lock.json
@@ -11,8 +11,8 @@
         "@maxgraph/core": "0.3.0"
       },
       "devDependencies": {
-        "typescript": "~5.1.6",
-        "vite": "~4.4.2"
+        "typescript": "~5.2.2",
+        "vite": "~4.4.11"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -448,9 +448,9 @@
       "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.26.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.2.tgz",
-      "integrity": "sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==",
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -514,14 +514,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.2.tgz",
-      "integrity": "sha512-zUcsJN+UvdSyHhYa277UHhiJ3iq4hUBwHavOpsNUGsTgjBeoBlK8eDt+iT09pBq0h9/knhG/SPrZiM7cGmg7NA==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
+      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
-        "postcss": "^8.4.24",
-        "rollup": "^3.25.2"
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -760,9 +760,9 @@
       }
     },
     "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "optional": true
     },
@@ -779,9 +779,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.6",
@@ -790,9 +790,9 @@
       }
     },
     "rollup": {
-      "version": "3.26.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.26.2.tgz",
-      "integrity": "sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==",
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -805,21 +805,21 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "vite": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.2.tgz",
-      "integrity": "sha512-zUcsJN+UvdSyHhYa277UHhiJ3iq4hUBwHavOpsNUGsTgjBeoBlK8eDt+iT09pBq0h9/knhG/SPrZiM7cGmg7NA==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
+      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.24",
-        "rollup": "^3.25.2"
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       }
     }
   }

--- a/projects/vitejs-ts/package.json
+++ b/projects/vitejs-ts/package.json
@@ -11,7 +11,7 @@
     "@maxgraph/core": "0.3.0"
   },
   "devDependencies": {
-    "typescript": "~5.1.6",
-    "vite": "~4.4.2"
+    "typescript": "~5.2.2",
+    "vite": "~4.4.11"
   }
 }


### PR DESCRIPTION
lit-element:
  - vite from 4.4.2 to 4.4.11
  - typescript from 5.1.6 to 5.2.2

parcel-ts
  - parcel from 2.9.3 to 2.10.0
  - typescript from 5.1.6 to 5.2.2

vitejs-ts:
  - vite from 4.4.2 to 4.4.11
  - typescript from 5.1.6 to 5.2.2

rollup-ts:
  - rollup and its dependencies to work with v4
  - typescript from 5.1.6 to 5.2.2