### PR TITLE
ci: automate release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version in the x.y.z form. Must match a released version of maxGraph'
+        required: true
+
+env:
+  VERSION: ${{ inputs.version }}
+  TAG: v${{ inputs.version }}
+
+jobs:
+  create_release:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write # create the GH release
+    steps:
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          body: |
+            Relates to [maxGraph ${{ env.VERSION }}](https://github.com/maxGraph/maxGraph/releases/tag/${{ env.TAG }}).
+          generateReleaseNotes: true
+          name: ${{ env.VERSION }}
+          tag: ${{ env.TAG }}

--- a/README.md
+++ b/README.md
@@ -48,3 +48,25 @@ In this folder where you clone the `maxgraph-integration-examples` project, go t
   Repack of maxgraph is automatically available in the examples
   - alternative: `npm install <path_to_locally_installed_maxgraph>/packages/core/maxgraph-core-0.1.0.tgz`. This changes
   the package.json file. You must run this command again each time you rebuild the maxgraph npm package.
+
+
+## Release
+
+Versioning scheme: follow version of maxGraph. For example, 0.5.0 uses maxgraph 0.5.0
+
+**TODO update the following**
+
+Once done, create a Pull Request in the [integration examples repository](https://github.com/maxGraph/maxgraph-integration-examples) to use the new release.
+- Dependencies in this repository are automatically updated by Dependabot, so you can trigger a new Dependabot run or wait for the next scheduled Dependabot run for this update to take place.
+- Validate that the examples work: use the artifact built by GitHub Actions to test the various applications locally.
+
+Then, create a [new draft release](https://github.com/maxGraph/maxgraph-integration-examples/releases):
+- name: use the same version as in `maxGraph`, like `0.2.1` 
+- tag: use the version prefixed with v, like `v0.2.1`
+- save it as a draft
+
+Generate the list of the major changes by using the [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
+
+Also add links to the releases previously created for `maxGraph`. As an example, see the release of the [0.2.1 version](https://github.com/maxGraph/maxgraph-integration-examples/releases/tag/v0.2.1).
+
+Publish the release.

--- a/README.md
+++ b/README.md
@@ -52,21 +52,12 @@ In this folder where you clone the `maxgraph-integration-examples` project, go t
 
 ## Release
 
-Versioning scheme: follow version of maxGraph. For example, 0.5.0 uses maxgraph 0.5.0
+The versioning in this repository follow the versioning of `maxGraph`. For example, version _0.5.0_ uses `maxGraph` _0.5.0_.
 
-**TODO update the following**
+So, prior releasing a new version of this version, the maxGraph version must have been updated:
+  - Dependencies in this repository are automatically updated by Dependabot, so you can trigger a new Dependabot run or wait for the next scheduled Dependabot run for this update to take place.
+  - Validate that the examples work: use the artifact built by GitHub Actions to test the various applications locally.
 
-Once done, create a Pull Request in the [integration examples repository](https://github.com/maxGraph/maxgraph-integration-examples) to use the new release.
-- Dependencies in this repository are automatically updated by Dependabot, so you can trigger a new Dependabot run or wait for the next scheduled Dependabot run for this update to take place.
-- Validate that the examples work: use the artifact built by GitHub Actions to test the various applications locally.
-
-Then, create a [new draft release](https://github.com/maxGraph/maxgraph-integration-examples/releases):
-- name: use the same version as in `maxGraph`, like `0.2.1` 
-- tag: use the version prefixed with v, like `v0.2.1`
-- save it as a draft
-
-Generate the list of the major changes by using the [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
-
-Also add links to the releases previously created for `maxGraph`. As an example, see the release of the [0.2.1 version](https://github.com/maxGraph/maxgraph-integration-examples/releases/tag/v0.2.1).
-
-Publish the release.
+Once maxGraph has been updated, the release can be done by running the [release workflow](https://github.com/maxGraph/maxgraph-integration-examples/actions/workflows/release.yml) which:
+  - creates the Git tag
+  - publishes a GitHub release including the [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).


### PR DESCRIPTION
Introduce a workflow that create the GitHub release and publish it along with the Git tag.

```[tasklist]
### Tasks
- [x] Add explanations in the README
- [x] Add a GitHub workflow to create the GH release that is currently created manually
- [x] In the maxGraph repository, create a doc PR to remove the update of the examples repo from the maxGraph release process https://github.com/maxGraph/maxGraph/pull/302
``` 