### PR TITLE
chore(dependabot): update svelte independently

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
     groups:
+      svelte:
+        patterns:
+          - "@sveltejs/"
+          - "svelte*"
       development-dependencies:
         dependency-type: "development"
 


### PR DESCRIPTION
Sveltekit must be updated to a major version which requires configuration changes. 
This will allow other dependencies to be updated while making changes to svelte in parallel.