### PR TITLE
chore(dependabot): fix update svelte independently

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
           - "svelte*"
       development-dependencies:
         dependency-type: "development"
+        exclude-patterns:
+          # updated in a dedicated group
+          - "@sveltejs/"
+          - "svelte*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Exclude svelte dependencies from the main group, otherwise svelte is also updated in this group.