### PR TITLE
feat: set a specific page title for each project

### DIFF
--- a/.github/workflows/check-typescript-projects.yml
+++ b/.github/workflows/check-typescript-projects.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           script: |
             const {PROJECTS_PATH} = process.env;
-            const projectsListing = PROJECTS_PATH.split(' ').filter(name => name.trim() !== '').map(name => `<li><a href="${name}/index.html" target="_blank">${name}</a></li>`).join('\n');
+            const projectsListing = PROJECTS_PATH.split(' ').filter(name => name.trim() !== '').map(name => `<li><a href="${name}/" target="_blank">${name}</a></li>`).join('\n');
             
             let htmlContent = `<!DOCTYPE html>
             <html lang="en">

--- a/.github/workflows/check-typescript-projects.yml
+++ b/.github/workflows/check-typescript-projects.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           script: |
             const {PROJECTS_PATH} = process.env;
-            const projectsListing = PROJECTS_PATH.split(' ').filter(name => name.trim() !== '').map(name => `<li><a href="${name}/" target="_blank">${name}</a></li>`).join('\n');
+            const projectsListing = PROJECTS_PATH.split(' ').filter(name => name.trim() !== '').map(name => `<li><a href="${name}/index.html" target="_blank">${name}</a></li>`).join('\n');
             
             let htmlContent = `<!DOCTYPE html>
             <html lang="en">

--- a/projects/lit-ts/index.html
+++ b/projects/lit-ts/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>maxGraph Lit integration example</title>
+    <title>maxGraph Lit Typescript example</title>
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <script type="module" src="/src/index.ts"></script>
   </head>
   <body>
-    <h1>maxGraph TypeScript example</h1>
+    <h1>maxGraph Lit Typescript example</h1>
     <p>Display a test graph. Activated behaviours:</p>
     <ul>
       <li>Panning: use mouse right button</li>

--- a/projects/parcel-ts/index.html
+++ b/projects/parcel-ts/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>maxGraph TypeScript example</title>
+    <title>maxGraph Parcel TypeScript example</title>
     <link rel="icon" type="image/ico" href="favicon.ico" />
     <script type="module" src="src/main.ts"></script>
   </head>
   <body>
-    <h1>maxGraph TypeScript example</h1>
+    <h1>maxGraph Parcel TypeScript example</h1>
     <p>Display a test graph. Activated behaviours:</p>
     <ul>
       <li>Panning: use mouse right button</li>

--- a/projects/rollup-ts/public/index.html
+++ b/projects/rollup-ts/public/index.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>maxGraph TypeScript example</title>
+    <title>maxGraph Rollup TypeScript example</title>
     <link rel="icon" type="image/png" href="favicon.png" />
     <link rel="stylesheet" href="style.css" />
     <script type="module" src='bundle.js'></script>
   </head>
   <body>
-    <h1>maxGraph TypeScript example</h1>
+    <h1>maxGraph Rollup TypeScript example</h1>
     <p>Display a test graph. Activated behaviours:</p>
     <ul>
       <li>Panning: use mouse right button</li>

--- a/projects/sveltekit-ts/src/routes/+layout.svelte
+++ b/projects/sveltekit-ts/src/routes/+layout.svelte
@@ -5,7 +5,11 @@
   import { Client } from '@maxgraph/core';
 </script>
 
-<h1>maxGraph SvelteKit-TypeScript example</h1>
+<svelte:head>
+  <title>maxGraph SvelteKit TypeScript example</title>
+</svelte:head>
+
+<h1>maxGraph SvelteKit TypeScript example</h1>
 <p>Display a test graph. Activated behaviours:</p>
 <ul>
   <li>Panning: use mouse right button</li>

--- a/projects/vitejs-ts/index.html
+++ b/projects/vitejs-ts/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>maxGraph TypeScript example</title>
+    <title>maxGraph Vite TypeScript example</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <script type="module" src="/src/main.ts"></script>
   </head>
   <body>
-    <h1>maxGraph TypeScript example</h1>
+    <h1>maxGraph Vite TypeScript example</h1>
     <p>Display a test graph. Activated behaviours:</p>
     <ul>
       <li>Panning: use mouse right button</li>


### PR DESCRIPTION
This makes it easy to identify one project from another. Add missing title in meta head for sveltekit.