### PR TITLE
chore(dependabot): update svelte with other dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,16 +13,8 @@ updates:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
     groups:
-      svelte:
-        patterns:
-          - "@sveltejs/*"
-          - "svelte*"
       development-dependencies:
         dependency-type: "development"
-        exclude-patterns:
-          # updated in a dedicated group
-          - "@sveltejs/*"
-          - "svelte*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Previously, svelte dependencies were updated independently because they require to be updated to a new major version, and the configuration required changes. The build was failing and prevented to update the dependencies of other projects. So, updating svelte independently let update the other dependencies. See 84b213d62102a7b9fd15cc3145cdb9d187d57fc7.

Svelte and sveltekit have been bumped to the latest available major versions, so this is no longer needed to update them independently.

### Notes

Sveltekit bump to the latest major version has been done in #154