### PR TITLE
docs: reference the farm project in the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Build the "shared" package:
 
 ### Available projects
 
+- [TypeScript with Farm](./projects/farm-ts/README.md)
 - [TypeScript with Lit](./projects/lit-ts/README.md)
 - [TypeScript with Parcel](./projects/parcel-ts/README.md)
 - [TypeScript with Rollup](./projects/rollup-ts/README.md)


### PR DESCRIPTION
It was missing in 3be7c1b9.