### PR TITLE
refactor: optimize by loading only required graph features

### DIFF
--- a/projects/_shared/src/custom-shapes.ts
+++ b/projects/_shared/src/custom-shapes.ts
@@ -3,6 +3,7 @@ import {CellRenderer, EllipseShape, RectangleShape} from '@maxgraph/core';
 
 export const registerCustomShapes = (): void => {
   console.info('Registering custom shapes...');
+  // TODO remove ts-ignore when maxGraph 0.18.0 is released
   // @ts-ignore TODO fix CellRenderer. Calls to this function are also marked as 'ts-ignore' in CellRenderer
   CellRenderer.registerShape('customRectangle', CustomRectangleShape);
   // @ts-ignore


### PR DESCRIPTION
Create `CustomGraph` that registers only the features needed by our examples instead of loading all built-in styles and shapes.

This prepares for future tree-shaking improvements in maxGraph which will reduce bundle size.

### Notes

https://github.com/maxGraph/maxGraph/issues/760