### PR TITLE
chore: add script to build all examples and improve parcel build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Build the "shared" package:
 - this package is used in all projects, so it must be built first.
 - for more details, see its [dedicated README](projects/_shared/README.md).
 
+**NOTE**: if you want to build all examples at once, you can run
+```bash
+./build-all-examples.bash
+```
+
 ### Available projects
 
 - [TypeScript with Farm](./projects/farm-ts/README.md)

--- a/build-all-examples.bash
+++ b/build-all-examples.bash
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script builds all examples in the packages directory.
+# From the root of the repository, run " ./build-all-examples.bash"
+
+
+# Check for command line arguments
+LIST_SIZE_ONLY=false
+if [[ $# -gt 0 && "$1" == "--list-size-only" ]]; then
+  LIST_SIZE_ONLY=true
+fi
+
+if [ "$LIST_SIZE_ONLY" = true ]; then
+  echo "Skip building examples."
+else
+  echo "Building all examples..."
+
+  npm run build -w projects/_shared
+  npm run build --workspaces
+
+
+#  for dir in packages/ts-example* packages/js-example*; do
+#    if [ -d "$dir" ]; then
+#      echo
+#      echo "##################################################"
+#      echo "Building $dir"
+#      echo "##################################################"
+#      (cd "$dir" && npm run build)
+#    fi
+#  done
+
+  echo "All examples built successfully."
+fi
+
+
+for dir in projects/*; do
+  if [ -d "$dir" ]; then
+    echo
+    echo "##################################################"
+    echo "Files in $dir/dist directory:"
+    echo "##################################################"
+
+    if [ -d "$dir/dist" ]; then
+      # Find all JS files and display sizes with 2 decimal places
+      # Use 1000 to match Vite's size display
+      find "$dir/dist" -name "*.js" -type f -exec ls -l {} \; | LC_NUMERIC=C awk '{
+        # Convert bytes to KB with 2 decimal places
+        size_kb = $5 / 1000
+        printf "%.2f kB %s\n", size_kb, $9
+      }'
+    else
+      echo "No dist directory found in $dir"
+    fi
+  fi
+done
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -4711,6 +4711,19 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
@@ -6615,6 +6628,118 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/del": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-8.0.0.tgz",
+      "integrity": "sha512-R6ep6JJ+eOBZsBr9esiNN1gxFbZE4Q2cULkUSFumGYecAiS6qodDvcPx/sFuWHMNul7DWmrtoEOpYSm7o6tbSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globby": "^14.0.2",
+        "is-glob": "^4.0.3",
+        "is-path-cwd": "^3.0.0",
+        "is-path-inside": "^4.0.0",
+        "p-map": "^7.0.2",
+        "slash": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/del-cli/-/del-cli-6.0.0.tgz",
+      "integrity": "sha512-9nitGV2W6KLFyya4qYt4+9AKQFL+c0Ehj5K7V7IwlxTc6RMCfQUGY9E9pLG6e8TQjtwXpuiWIGGZb3mfVxyZkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "del": "^8.0.0",
+        "meow": "^13.2.0"
+      },
+      "bin": {
+        "del": "cli.js",
+        "del-cli": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del/node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del/node_modules/ignore": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
+      "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/del/node_modules/p-map": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del/node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -8422,6 +8547,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-path-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-3.0.0.tgz",
+      "integrity": "sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -9407,6 +9558,19 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -11842,6 +12006,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -12365,6 +12542,7 @@
     "projects/parcel-ts": {
       "name": "maxgraph-ts-example-built-with-parcel",
       "devDependencies": {
+        "del-cli": "~6.0.0",
         "parcel": "~2.15.0"
       }
     },

--- a/projects/parcel-ts/package.json
+++ b/projects/parcel-ts/package.json
@@ -4,9 +4,10 @@
   "type": "module",
   "scripts": {
     "dev": "parcel index.html",
-    "build": "tsc && parcel build --public-url ./ index.html"
+    "build": "tsc && del dist && parcel build --public-url ./ index.html"
   },
   "devDependencies": {
+    "del-cli": "~6.0.0",
     "parcel": "~2.15.0"
   }
 }


### PR DESCRIPTION
- Add a script to build all example projects at once, simplifying the build process.
- Ensure the "shared" package is built first, as it is required by all examples.
- The script lists the size of the generated JavaScript files, making it easier to compare bundle sizes across different maxGraph versions.
- Update the Parcel build to always clean the dist folder before building, as Parcel does not do this automatically. This prevents outdated files from previous builds from being included.

### Notes

The script is adapted from the maxGraph repository. See https://github.com/maxGraph/maxGraph/pull/822