### PR TITLE
refactor: check that the plugin is available prior setting properties

### DIFF
--- a/projects/_shared/src/generate-graph.ts
+++ b/projects/_shared/src/generate-graph.ts
@@ -64,7 +64,8 @@ export const initializeGraph = (container?: HTMLElement) => {
     graph.setPanning(true); // Use mouse right button for panning
 
     // Customize the rubber band selection
-    graph.getPlugin<RubberBandHandler>('RubberBandHandler').fadeOut = true;
+    const rubberBandHandler = graph.getPlugin<RubberBandHandler>('RubberBandHandler');
+    rubberBandHandler && (rubberBandHandler.fadeOut = true);
 
     // create a dedicated style for "ellipse" to share properties
     graph.getStylesheet().putCellStyle('myEllipse', {


### PR DESCRIPTION
In the next maxGraph version, `Abstract.getPlugin` may return `undefined`, so a TSC error is thrown if the code doesn't verify that the plugin is present.